### PR TITLE
Disable cypress screenshots during CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,14 @@ jobs:
         run: npm run lint
 
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           build: npm run build --if-present
           start: npm start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 120
           working-directory: ./src/client
+          config: screenshotOnRunFailure=false
         env:
           REACT_APP_VERSION: 0.0.99+dev
           TZ: Europe/Zurich


### PR DESCRIPTION
And update the GitHub Action version along the way.