### PR TITLE
Fix app crash when changing the borehole location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Fix partly unresponsive UI by avoiding unnecessary data loading on startup.
+- Fix bug where setting or changing the borehole location on the map in editor mode caused the application to freeze.
 
 ## v2.0.133 - 2023-01-19
 

--- a/src/client/src/commons/map/pointComponent.js
+++ b/src/client/src/commons/map/pointComponent.js
@@ -42,7 +42,7 @@ class PointComponent extends React.Component {
   constructor(props) {
     super(props);
     this.lh = false; // loading location queue
-    this.changefeature = this.changefeature.bind(this);
+    this.changefeature = this.updatePointAndGetAddress.bind(this);
     this.styleFunction = this.styleFunction.bind(this);
     this.getAddress = this.getAddress.bind(this);
     this.zoomtopoly = this.zoomtopoly.bind(this);
@@ -156,8 +156,11 @@ class PointComponent extends React.Component {
       }),
     );
 
-    this.position.on("addfeature", this.changefeature, this);
-    this.position.on("changefeature", this.changefeature, this);
+    this.position.on(
+      "addfeature",
+      e => this.updatePointAndGetAddress(e.feature),
+      this,
+    );
 
     if (this.props.x !== 0 && this.props.y !== 0) {
       this.manageMapInteractions();
@@ -184,14 +187,22 @@ class PointComponent extends React.Component {
               this.getAddress(point);
             },
           );
-          this.position.un("changefeature", this.changefeature, this);
-          this.position.un("addfeature", this.changefeature, this);
+
+          this.position.un(
+            "addfeature",
+            e => this.updatePointAndGetAddress(e.feature),
+            this,
+          );
           this.drawOrUpdatePoint(point);
           this.map
             .getView()
             .fit(this.centerFeature.getGeometry(), { resolution: 1 });
-          this.position.on("changefeature", this.changefeature, this);
-          this.position.on("addfeature", this.changefeature, this);
+
+          this.position.on(
+            "addfeature",
+            e => this.updatePointAndGetAddress(e.feature),
+            this,
+          );
         }
       }
     }
@@ -261,6 +272,11 @@ class PointComponent extends React.Component {
         source: this.position,
       });
     }
+
+    this.modify.on("modifyend", e =>
+      this.updatePointAndGetAddress(e.features.array_[0]),
+    );
+
     this.map.addInteraction(this.modify);
     this.map.removeInteraction(this.draw);
   }
@@ -275,13 +291,13 @@ class PointComponent extends React.Component {
     });
   }
 
-  /*
-      Function fired as soon the editing vector source
-      is changed.
-  */
-  changefeature(ev) {
+  /**
+   * Updates the point state and queries the address of the given point location.
+   * This method gets called everytime a feature is added or edited.
+   * @param {Feature} feature
+   */
+  updatePointAndGetAddress(feature) {
     const { changefeature, isEditable } = this.props;
-    let feature = ev.feature;
     let coordinates = feature.getGeometry().getCoordinates();
     if (this.centerFeature === undefined) {
       this.centerFeature = feature;


### PR DESCRIPTION
Previously the address was queried on every single move while dragging the point on the map causing the application to crash. Now the address gets only queried once when the point has been changed.

Fixes #266 