### PR TITLE
Extend sql command timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,4 +112,4 @@ services:
     environment:
       ASPNETCORE_URLS: http://+:5000
       DOTNET_USE_POLLING_FILE_WATCHER: 1
-      CONNECTIONSTRINGS__BdmsContext: Host=db;Username=SPAWNPLOW;Password=YELLOWSPATULA;Database=bdms
+      CONNECTIONSTRINGS__BdmsContext: Host=db;Username=SPAWNPLOW;Password=YELLOWSPATULA;Database=bdms;CommandTimeout=100


### PR DESCRIPTION
in development environment in order to prevent timouts when seeding layers at startup.

#34 