### PR TITLE
Increase cypress viewport and screenshot size

### DIFF
--- a/src/client/cypress.config.js
+++ b/src/client/cypress.config.js
@@ -4,6 +4,8 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: "http://localhost:3000",
     video: false,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
     supportFile: "cypress/support/e2e.js",
     setupNodeEvents(on, config) {
       on("task", {
@@ -12,6 +14,15 @@ module.exports = defineConfig({
 
           return null;
         },
+      });
+
+      on("before:browser:launch", (browser, launchOptions) => {
+        launchOptions.preferences.width = 1920;
+        launchOptions.preferences.height = 1080;
+        launchOptions.preferences.frame = false;
+        launchOptions.preferences.useContentSize = true;
+
+        return launchOptions;
       });
     },
   },


### PR DESCRIPTION
Die erzeugten Screenshots zeigen nun das ganze UI an.