### PR TITLE
Reduce depth options to avoid overlaps

### DIFF
--- a/src/client/cypress/e2e/editor/lithologicalDescription.cy.js
+++ b/src/client/cypress/e2e/editor/lithologicalDescription.cy.js
@@ -10,13 +10,6 @@ describe("Tests for the lithological description column.", () => {
     cy.get('[data-cy="add-stratigraphy-button"]').click();
     cy.wait("@stratigraphy_edit_create");
 
-    // try add lithological description without lithology
-    cy.get('[data-cy="add-litho-desc-icon"]').click();
-    cy.wait("@lithological_description");
-
-    // assure cannot add lithological description without lithology
-    cy.get('[data-cy="lithological-description-0"]').should("not.exist");
-
     // add three layers
     cy.get('[data-cy="add-layer-icon"]').click();
     cy.wait("@layer");
@@ -48,6 +41,7 @@ describe("Tests for the lithological description column.", () => {
     cy.wait("@layer");
     cy.get('[data-cy="styled-layer-2"] [data-testid="ClearIcon"]').click();
 
+    // add lithological description
     cy.get('[data-cy="add-litho-desc-icon"]').click();
     cy.wait("@lithological_description");
     cy.get('[data-cy="lithological-description-0"]').contains("0 m");
@@ -70,16 +64,6 @@ describe("Tests for the lithological description column.", () => {
     cy.get('.MuiPaper-elevation [role="listbox"]')
       .find('[role="option"]')
       .last()
-      .click();
-
-    // fill to depth dropdown
-    cy.get('[data-cy="to-depth-select"]')
-      .find('[role="button"]')
-      .click({ force: true });
-
-    cy.get('.MuiPaper-elevation [role="listbox"]')
-      .find('[role="option"]')
-      .eq(1)
       .click();
 
     // stop editing
@@ -110,7 +94,7 @@ describe("Tests for the lithological description column.", () => {
 
     cy.get('.MuiPaper-elevation [role="listbox"]')
       .find('[role="option"]')
-      .eq(2)
+      .eq(1)
       .click();
     cy.wait("@lithological_description");
 
@@ -140,15 +124,6 @@ describe("Tests for the lithological description column.", () => {
     cy.get(
       '[data-cy="lithological-description-1"] [data-testid="ModeEditIcon"] ',
     ).click();
-    cy.get('[data-cy="to-depth-select"]')
-      .find('[role="button"]')
-      .click({ force: true });
-
-    cy.get('.MuiPaper-elevation [role="listbox"]')
-      .find('[role="option"]')
-      .eq(1)
-      .click();
-    cy.wait("@lithological_description");
     cy.wait("@lithological_description");
 
     // stop editing
@@ -163,14 +138,6 @@ describe("Tests for the lithological description column.", () => {
     cy.get(
       '[data-cy="lithological-description-2"] [data-testid="ModeEditIcon"] ',
     ).click();
-    cy.get('[data-cy="to-depth-select"]')
-      .find('[role="button"]')
-      .click({ force: true });
-
-    cy.get('.MuiPaper-elevation [role="listbox"]')
-      .find('[role="option"]')
-      .eq(1)
-      .click();
     cy.wait("@lithological_description");
 
     // stop editing

--- a/src/client/src/commons/form/profile/components/profileLayers/components/lithologicalDescriptionLayers/lithologicalDescriptionInput.js
+++ b/src/client/src/commons/form/profile/components/profileLayers/components/lithologicalDescriptionLayers/lithologicalDescriptionInput.js
@@ -20,15 +20,66 @@ const LithologicalDescriptionInput = props => {
     setQtDescriptionId,
     selectableToDepths,
     selectableFromDepths,
+    lithologicalDescriptions,
   } = props;
   const { t, i18n } = useTranslation();
   const domains = useDomains();
+
+  const closestTopLayer =
+    lithologicalDescriptions[lithologicalDescriptions.indexOf(item) - 1];
+
+  const closestBottomLayer =
+    lithologicalDescriptions[lithologicalDescriptions.indexOf(item) + 1];
+
+  const getFromDepthOptions = () => {
+    // get all depths that are not yet in use and that are smaller than toDepth
+    let options = selectableFromDepths.filter(
+      d =>
+        !lithologicalDescriptions.map(l => l.fromDepth).includes(d) &&
+        d < item.toDepth,
+    );
+    // only allow selecting depths in the gap above the layer
+    if (closestTopLayer !== undefined) {
+      if (closestTopLayer.toDepth === item.fromDepth) {
+        options = options.filter(d => d >= item.fromDepth);
+      } else {
+        options = options.filter(d => d >= closestTopLayer.fromDepth);
+      }
+    }
+    // keep currently selected option
+    options.push(item.fromDepth);
+    return options.sort((a, b) => a - b);
+  };
+
+  const getToDepthOptions = () => {
+    // get all depths that are not yet in use and that are greater than fromDepth
+    let options = selectableToDepths.filter(
+      d =>
+        !lithologicalDescriptions.map(l => l.toDepth).includes(d) &&
+        d > item.fromDepth,
+    );
+    // only allow selecting depths in the gap below the layer
+    if (closestBottomLayer !== undefined) {
+      if (closestBottomLayer.fromDepth === item.toDepth) {
+        options = options.filter(d => d <= item.toDepth);
+      } else {
+        options = options.filter(d => d <= closestBottomLayer.toDepth);
+      }
+    }
+    // keep currently selected option
+    options.push(item.toDepth);
+    return options.sort((a, b) => a - b);
+  };
+
+  const fromDepthOptions = getFromDepthOptions();
+  const toDepthOptions = getToDepthOptions();
 
   return (
     <Stack direction="column" sx={{ width: "100%" }}>
       <FormControl variant="standard" sx={{ minWidth: 120 }} size="small">
         <InputLabel htmlFor="from-depth">{t("layer_depth_from")}</InputLabel>
         <Select
+          disabled={fromDepthOptions.length === 1}
           data-cy="from-depth-select"
           defaultValue={item.fromDepth}
           input={<Input id="from-depth" />}
@@ -36,10 +87,7 @@ const LithologicalDescriptionInput = props => {
             e.stopPropagation();
             setFromDepth(e.target.value);
           }}>
-          <MenuItem value="">
-            <em>{t("reset")}</em>
-          </MenuItem>
-          {selectableFromDepths.map(d => (
+          {fromDepthOptions.map(d => (
             <MenuItem value={d}>{d}</MenuItem>
           ))}
         </Select>
@@ -83,6 +131,7 @@ const LithologicalDescriptionInput = props => {
       <FormControl variant="standard" sx={{ minWidth: 120 }} size="small">
         <InputLabel htmlFor="to-depth">{t("layer_depth_to")}</InputLabel>
         <Select
+          disabled={toDepthOptions.length === 1}
           data-cy="to-depth-select"
           defaultValue={item.toDepth}
           input={<Input id="to-depth" />}
@@ -90,14 +139,9 @@ const LithologicalDescriptionInput = props => {
             e.stopPropagation();
             setToDepth(e.target.value);
           }}>
-          <MenuItem value="">
-            <em>{t("reset")}</em>
-          </MenuItem>
-          {selectableToDepths
-            ?.filter(d => d > item.fromDepth)
-            .map(d => (
-              <MenuItem value={d}>{d}</MenuItem>
-            ))}
+          {toDepthOptions.map(d => (
+            <MenuItem value={d}>{d}</MenuItem>
+          ))}
         </Select>
       </FormControl>
     </Stack>

--- a/src/client/src/commons/form/profile/components/profileLayers/components/lithologicalDescriptionLayers/lithologicalDescriptionInput.js
+++ b/src/client/src/commons/form/profile/components/profileLayers/components/lithologicalDescriptionLayers/lithologicalDescriptionInput.js
@@ -99,7 +99,7 @@ const LithologicalDescriptionInput = props => {
         rows={3}
         placeholder={t("description")}
         hiddenLabel
-        value={item.description}
+        defaultValue={item.description ?? ""}
         onChange={e => {
           setDescription(e.target.value);
         }}

--- a/src/client/src/commons/form/profile/components/profileLayers/components/lithologicalDescriptionLayers/lithologicalDescriptionLayers.js
+++ b/src/client/src/commons/form/profile/components/profileLayers/components/lithologicalDescriptionLayers/lithologicalDescriptionLayers.js
@@ -243,6 +243,7 @@ const LithologicalDescriptionLayers = props => {
                       setQtDescriptionId={setQtDescriptionId}
                       selectableFromDepths={selectableFromDepths}
                       selectableToDepths={selectableToDepths}
+                      lithologicalDescriptions={lithologicalDescriptions}
                       item={item}
                     />
                   )}

--- a/src/client/src/commons/form/profile/components/profileLayers/profileLayers.js
+++ b/src/client/src/commons/form/profile/components/profileLayers/profileLayers.js
@@ -104,10 +104,13 @@ const ProfileLayers = props => {
       alertContext.error(t("first_add_layer_to_depth"));
     } else {
       setSelectedLithologicalDescription(null);
+      const newFromDepth = lithoDescQuery?.data?.at(-1)?.toDepth ?? 0;
       layers?.data?.length !== 0
         ? addMutation.mutate({
             stratigraphyId: selectedStratigraphyID,
-            fromDepth: lithoDescQuery?.data?.at(-1)?.toDepth ?? 0,
+            fromDepth: newFromDepth,
+            toDepth: layers.data.find(l => l.depth_from === newFromDepth)
+              .depth_to,
           })
         : alertContext.error(t("first_add_lithology"));
     }

--- a/src/client/src/commons/form/profile/components/profileLayers/profileLayers.js
+++ b/src/client/src/commons/form/profile/components/profileLayers/profileLayers.js
@@ -109,8 +109,8 @@ const ProfileLayers = props => {
         ? addMutation.mutate({
             stratigraphyId: selectedStratigraphyID,
             fromDepth: newFromDepth,
-            toDepth: layers.data.find(l => l.depth_from === newFromDepth)
-              .depth_to,
+            toDepth: layers?.data.find(l => l.depth_from === newFromDepth)
+              ?.depth_to,
           })
         : alertContext.error(t("first_add_lithology"));
     }


### PR DESCRIPTION
Resolves #389 

Wir haben uns dazu entschieden die Benutzerführung so anzupassen, dass Überschneidungen gar nicht erst eingegeben werden können und wir somit die Fehler vermeiden  statt komplizierten Fehlermeldungen mit Lösungsoptionen anzuzeigen. 
Im Gegensatz zu Lücken in der Schicht sind Überlappungen ja kein plausibles Szenario in der Schichtenabfolge.
Den Benutzenden stehen trotzdem alle Eingabeoptionen zur Verfügung.