### PR TITLE
Reset boreholes with API calls

### DIFF
--- a/src/client/cypress/e2e/editor/bulkedit.cy.js
+++ b/src/client/cypress/e2e/editor/bulkedit.cy.js
@@ -1,13 +1,15 @@
-import { createBorehole } from "../testHelpers";
+import { createBorehole, login } from "../testHelpers";
 
 describe("Test the borehole bulk edit feature.", () => {
   it("opens the bulk edit dialog with all boreholes selected", () => {
+    login("/editor");
     cy.get('[data-cy="borehole-table"] thead .checkbox').click({ force: true });
     cy.contains("button", "Bulk editing").click({ force: true });
     cy.wait("@edit_ids");
   });
 
   it("checks if all toggle buttons do something", () => {
+    login("/editor");
     cy.get('[data-cy="borehole-table"] thead .checkbox').click({ force: true });
     cy.contains("button", "Bulk editing").click({ force: true });
 
@@ -22,6 +24,8 @@ describe("Test the borehole bulk edit feature.", () => {
   });
 
   it("fills all bulkedit fields and saves.", () => {
+    login("/editor");
+
     // create boreholes
     createBorehole({ "extended.original_name": "NINTIC" }).as("borehole_id_1");
     createBorehole({ "extended.original_name": "LOMONE" }).as("borehole_id_2");

--- a/src/client/cypress/e2e/editor/copyBorehole.cy.js
+++ b/src/client/cypress/e2e/editor/copyBorehole.cy.js
@@ -1,7 +1,8 @@
-import { createBorehole } from "../testHelpers";
+import { createBorehole, login } from "../testHelpers";
 
 describe("Test copying of boreholes", () => {
   it("copies a borehole", () => {
+    login("/editor");
     createBorehole({ "extended.original_name": "NINTIC" }).as("borehole_id_1");
 
     cy.get('[data-cy="borehole-table"] tbody')

--- a/src/client/cypress/e2e/filter.cy.js
+++ b/src/client/cypress/e2e/filter.cy.js
@@ -55,6 +55,7 @@ describe("Search filter tests", () => {
 
   it("checks that the registration filter settings control the filter visibility.", () => {
     // precondition filters not visible
+    login("/editor");
     cy.contains("Registration").click();
     cy.contains("Show all fields")
       .next()
@@ -88,6 +89,7 @@ describe("Search filter tests", () => {
   });
 
   it("filters boreholes by creator name", () => {
+    login("/editor");
     cy.contains("Registration").click();
     cy.contains("Show all fields").children(".checkbox").click();
 
@@ -105,6 +107,7 @@ describe("Search filter tests", () => {
   });
 
   it("filters boreholes by original lithology", () => {
+    login("/editor");
     cy.contains("Stratigraphy").click();
     cy.contains("Show all fields").children(".checkbox").click();
 
@@ -119,6 +122,7 @@ describe("Search filter tests", () => {
   });
 
   it("filters boreholes by creation date", () => {
+    login("/editor");
     cy.contains("Registration").click();
     cy.contains("Show all fields").children(".checkbox").click();
 

--- a/src/client/cypress/e2e/srsFilter.cy.js
+++ b/src/client/cypress/e2e/srsFilter.cy.js
@@ -44,6 +44,7 @@ describe("Tests for filtering data by reference system.", () => {
   });
 
   it("can set filters as editor", () => {
+    login("/editor");
     goToEditorLocationFilter();
 
     cy.contains("div", "Spatial reference system")

--- a/src/client/cypress/e2e/viewer/displayLayer.cy.js
+++ b/src/client/cypress/e2e/viewer/displayLayer.cy.js
@@ -1,8 +1,9 @@
-import { newEditableBorehole } from "../testHelpers";
+import { newEditableBorehole, login } from "../testHelpers";
 
 describe("Test for the borehole form.", () => {
   beforeEach(() => {
     // Assert map number of boreholes
+    login("/editor");
     cy.get("div[id=map]").should("be.visible");
     cy.get("tbody").children().should("have.length", 100);
 


### PR DESCRIPTION
Do not rely on UI for resetting data during tests. This also removes the indirect assumption that the login has been made by the global `loginAndResetState()` method.