### PR TITLE
Revert "Use react-query for fetching instruments"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Memorize table and map state when navigating through the application.
 - When leaving settings page, correctly navigate back to the previously selected mode (viewer or editor).
 - Display loader icon when fetching data for stratigraphy or users.
-- Improved loading time of instrument list.
 
 ### Fixed
 

--- a/src/client/src/commons/form/profile/components/profileInstrument/api/index.js
+++ b/src/client/src/commons/form/profile/components/profileInstrument/api/index.js
@@ -6,7 +6,6 @@ import {
   createStratigraphy,
   createInstrument,
 } from "../../../../../../api-lib/index";
-import { useQuery } from "react-query";
 
 let stratigraphyId = null;
 export const createNewStratigraphy = async (id, kind) => {
@@ -39,14 +38,6 @@ export const getProfile = async (id, kind) => {
       console.error(error);
     });
   return profiles;
-};
-
-export const useProfiles = (boreholeId, kind) => {
-  return useQuery(
-    ["profiles", boreholeId, kind],
-    () => getProfile(boreholeId, kind),
-    { staleTime: 5000 },
-  );
 };
 
 let data = [];

--- a/src/client/src/commons/form/profile/hooks/useCasingList.js
+++ b/src/client/src/commons/form/profile/hooks/useCasingList.js
@@ -1,22 +1,21 @@
 import { useState, useEffect, useRef } from "react";
 import { profileKind } from "../constance";
 import { useTranslation } from "react-i18next";
-import { useProfiles } from "../components/profileInstrument/api";
+import { getProfile } from "../components/profileInstrument/api";
 
 export default function useCasingList(boreholeID) {
   const { t } = useTranslation();
 
   const [casing, setCasing] = useState([]);
   const mounted = useRef(false);
-  const { data: profiles } = useProfiles(boreholeID, profileKind.CASING);
 
   useEffect(() => {
     mounted.current = true;
 
-    if (profiles) {
+    getProfile(boreholeID, profileKind.CASING).then(response => {
       const temp = [{ key: 1, value: 0, text: t("common:no_casing") }];
-      if (profiles.length > 0) {
-        profiles.forEach(e => {
+      if (response.length > 0) {
+        response.forEach(e => {
           temp.push({
             key: e.id,
             value: e.id,
@@ -27,12 +26,12 @@ export default function useCasingList(boreholeID) {
       if (mounted.current) {
         setCasing(temp);
       }
-    }
+    });
 
     return () => {
       mounted.current = false;
     };
-  }, [t, profiles]);
+  }, [boreholeID, t]);
 
   return { casing };
 }


### PR DESCRIPTION
Reverts geoadmin/suite-bdms#451

This change had no effect and causes unnecessary cache invalidation requests.
#426 