### PR TITLE
Remove blue info button of displayed maps in map settings

### DIFF
--- a/src/client/src/commons/map/overlay/mapOverlayCmp.js
+++ b/src/client/src/commons/map/overlay/mapOverlayCmp.js
@@ -108,62 +108,6 @@ class MapOverlayComponent extends React.Component {
                   />
                 </div>
                 <div>
-                  {setSelectedLayer === undefined ? null : layer.queryable ===
-                    false ? (
-                    <Popup
-                      content="Not queryable"
-                      on="hover"
-                      trigger={
-                        <Icon.Group size="large">
-                          <Icon color="red" name="dont" />
-                          <Icon name="info" size="tiny" />
-                        </Icon.Group>
-                      }
-                    />
-                  ) : (
-                    <Button
-                      active={
-                        this.state.selectedLayer !== null &&
-                        this.state.selectedLayer.Identifier === layer.Identifier
-                      }
-                      circular
-                      color={
-                        this.state.selectedLayer !== null &&
-                        this.state.selectedLayer.Identifier === layer.Identifier
-                          ? "blue"
-                          : null
-                      }
-                      compact
-                      icon
-                      onClick={() => {
-                        if (
-                          this.state.selectedLayer !== null &&
-                          this.state.selectedLayer.Identifier ===
-                            layer.Identifier
-                        ) {
-                          this.setState(
-                            {
-                              selectedLayer: null,
-                            },
-                            () => {
-                              setSelectedLayer(null);
-                            },
-                          );
-                        } else {
-                          this.setState(
-                            {
-                              selectedLayer: layer,
-                            },
-                            () => {
-                              setSelectedLayer(layer);
-                            },
-                          );
-                        }
-                      }}
-                      size="mini">
-                      <Icon name="info" />
-                    </Button>
-                  )}
                   <Button
                     circular
                     compact


### PR DESCRIPTION
Checked if button have some info which is just not displayed for some reason. But it is not applicable from where this info should be fetched.

Resolves #382 