### PR TITLE
Use built-in GITHUB_TOKEN in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,7 @@ on:
 env:
   REGISTRY: ghcr.io
   TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
-  GH_TOKEN: ${{ secrets.GH_GEOW_BUILD }}
-  GITHUB_TOKEN: ${{ secrets.GH_GEOW_BUILD }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   retag-docker-image:


### PR DESCRIPTION
Due to updated workflow trigger in #478 a dedicated personal access token is not needed anymore.

**remark**: _GH_TOKEN_ und _GITHUB_TOKEN_ sind gemäss [Doku](https://cli.github.com/manual/gh_help_environment) der GH CLI beide korrekt, resp. es müssen daher nicht beide gesetzt werden.

Das Secret _GH_GEOW_BUILD_ werde ich gleich noch aus der GitHub Umgebgung entfernen.