### PR TITLE
Enable auto retries for failing cypress tests

### DIFF
--- a/src/client/cypress.config.js
+++ b/src/client/cypress.config.js
@@ -30,4 +30,5 @@ module.exports = defineConfig({
   defaultCommandTimeout: 10000,
   waitForAnimations: false,
   animationDistanceThreshold: 50,
+  retries: 3
 });


### PR DESCRIPTION
Resolves #839 