### PR TITLE
Set ASPNETCORE_HTTP_PORTS to port 80

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -34,6 +34,7 @@ RUN dotnet publish \
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS deploy
 ENV ASPNETCORE_ENVIRONMENT=Production
+ENV ASPNETCORE_HTTP_PORTS=80
 WORKDIR /app
 
 # Install missing packages


### PR DESCRIPTION
By default the port 8080 is used in .NET 8 docker images: https://andrewlock.net/exploring-the-dotnet-8-preview-updates-to-docker-images-in-dotnet-8/#asp-net-core-apps-now-use-port-8080-by-default

#854 