### PR TITLE
Simplify IsBoreholeLockedAsync

### DIFF
--- a/src/api/BoreholeLockService.cs
+++ b/src/api/BoreholeLockService.cs
@@ -36,14 +36,14 @@ public class BoreholeLockService(BdmsContext context, ILogger<BoreholeLockServic
 
         if (!user.WorkgroupRoles.Any(x => x.WorkgroupId == borehole.WorkgroupId && userWorkflowRoles.Contains(x.Role)))
         {
-            logger.LogWarning("Current user with subject_id <{SubjectId}> does not have the required role to create a stratigraphy for borehole with id <{BoreholeId}>.", subjectId, boreholeId);
+            logger.LogWarning("Current user with subject_id <{SubjectId}> does not have the required role to edit the borehole with id <{BoreholeId}>.", subjectId, boreholeId);
             return true;
         }
 
         if (borehole.Locked.HasValue && borehole.Locked.Value.AddMinutes(LockTimeoutInMinutes) > timeProvider.GetUtcNow() && borehole.LockedById != user.Id)
         {
             var lockedUserFullName = $"{borehole.LockedBy?.FirstName} {borehole.LockedBy?.LastName}";
-            logger.LogWarning("Current user with subject_id <{SubjectId}> tried to create a stratigraphy for borehole with id <{BoreholeId}>, but the borehole is locked by user <{LockedByUserName}>.", subjectId, boreholeId, lockedUserFullName);
+            logger.LogWarning("Current user with subject_id <{SubjectId}> tried to edit borehole with id <{BoreholeId}>, but the borehole is locked by user <{LockedByUserName}>.", subjectId, boreholeId, lockedUserFullName);
             return true;
         }
 

--- a/src/api/BoreholeLockService.cs
+++ b/src/api/BoreholeLockService.cs
@@ -37,7 +37,7 @@ public class BoreholeLockService(BdmsContext context, ILogger<BoreholeLockServic
         if (!user.WorkgroupRoles.Any(x => x.WorkgroupId == borehole.WorkgroupId && userWorkflowRoles.Contains(x.Role)))
         {
             logger.LogWarning("Current user with subject_id <{SubjectId}> does not have the required role to create a stratigraphy for borehole with id <{BoreholeId}>.", subjectId, boreholeId);
-            throw new UnauthorizedAccessException();
+            return true;
         }
 
         if (borehole.Locked.HasValue && borehole.Locked.Value.AddMinutes(LockTimeoutInMinutes) > timeProvider.GetUtcNow() && borehole.LockedById != user.Id)

--- a/src/api/Controllers/CompletionController.cs
+++ b/src/api/Controllers/CompletionController.cs
@@ -68,10 +68,9 @@ public class CompletionController : BdmsControllerBase<Completion>
         try
         {
             // Check if associated borehole is locked
-            var subjectId = HttpContext.GetUserSubjectId();
-            if (await boreholeLockService.IsBoreholeLockedAsync(entity.BoreholeId, subjectId).ConfigureAwait(false))
+            if (await boreholeLockService.IsBoreholeLockedAsync(entity.BoreholeId, HttpContext.GetUserSubjectId()).ConfigureAwait(false))
             {
-                return Problem("The borehole is locked by another user.");
+                return Problem("The borehole is locked by another user or you are missing permissions.");
             }
 
             // If the completion to create is the first completion of a borehole,
@@ -102,10 +101,6 @@ public class CompletionController : BdmsControllerBase<Completion>
 
             return await base.CreateAsync(entity).ConfigureAwait(false);
         }
-        catch (UnauthorizedAccessException)
-        {
-            return Unauthorized("You are not authorized to create a completion for this borehole.");
-        }
         catch (Exception ex)
         {
             var message = "An error ocurred while creating the completion.";
@@ -121,10 +116,9 @@ public class CompletionController : BdmsControllerBase<Completion>
         try
         {
             // Check if associated borehole is locked
-            var subjectId = HttpContext.GetUserSubjectId();
-            if (await boreholeLockService.IsBoreholeLockedAsync(entity.BoreholeId, subjectId).ConfigureAwait(false))
+            if (await boreholeLockService.IsBoreholeLockedAsync(entity.BoreholeId, HttpContext.GetUserSubjectId()).ConfigureAwait(false))
             {
-                return Problem("The borehole is locked by another user.");
+                return Problem("The borehole is locked by another user or you are missing permissions.");
             }
 
             var editResult = await base.EditAsync(entity).ConfigureAwait(false);
@@ -149,10 +143,6 @@ public class CompletionController : BdmsControllerBase<Completion>
             }
 
             return editResult;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return Unauthorized("You are not authorized to edit to this completion.");
         }
         catch (Exception ex)
         {
@@ -187,10 +177,9 @@ public class CompletionController : BdmsControllerBase<Completion>
             }
 
             // Check if associated borehole is locked
-            var subjectId = HttpContext.GetUserSubjectId();
-            if (await boreholeLockService.IsBoreholeLockedAsync(completion.BoreholeId, subjectId).ConfigureAwait(false))
+            if (await boreholeLockService.IsBoreholeLockedAsync(completion.BoreholeId, HttpContext.GetUserSubjectId()).ConfigureAwait(false))
             {
-                return Problem("The borehole is locked by another user.");
+                return Problem("The borehole is locked by another user or you are missing permissions.");
             }
 
             // Set ids of copied entities to zero. Entities with an id of zero are added as new entities to the DB.
@@ -219,10 +208,6 @@ public class CompletionController : BdmsControllerBase<Completion>
 
             return Ok(entityEntry.Entity.Id);
         }
-        catch (UnauthorizedAccessException)
-        {
-            return Unauthorized("You are not authorized to copy this completion.");
-        }
         catch (Exception ex)
         {
             var message = "An error ocurred while copying the completion.";
@@ -245,10 +230,9 @@ public class CompletionController : BdmsControllerBase<Completion>
             }
 
             // Check if associated borehole is locked
-            var subjectId = HttpContext.GetUserSubjectId();
-            if (await boreholeLockService.IsBoreholeLockedAsync(completionToDelete.BoreholeId, subjectId).ConfigureAwait(false))
+            if (await boreholeLockService.IsBoreholeLockedAsync(completionToDelete.BoreholeId, HttpContext.GetUserSubjectId()).ConfigureAwait(false))
             {
-                return Problem("The borehole is locked by another user.");
+                return Problem("The borehole is locked by another user or you are missing permissions.");
             }
 
             Context.Remove(completionToDelete);
@@ -273,10 +257,6 @@ public class CompletionController : BdmsControllerBase<Completion>
             }
 
             return Ok();
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return Unauthorized("You are not authorized to delete this completion.");
         }
         catch (Exception ex)
         {

--- a/tests/BoreholeLockServiceTest.cs
+++ b/tests/BoreholeLockServiceTest.cs
@@ -45,7 +45,7 @@ public class BoreholeLockServiceTest
     public async Task IsBoreholeLockedWithUnauthorizedUser()
     {
         var borehole = await context.Boreholes.FirstAsync();
-        await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(async () => await boreholeLockService.IsBoreholeLockedAsync(borehole.Id, "sub_deletableUser"));
+        Assert.AreEqual(true, await boreholeLockService.IsBoreholeLockedAsync(borehole.Id, "sub_deletableUser"));
     }
 
     [TestMethod]
@@ -57,7 +57,7 @@ public class BoreholeLockServiceTest
         var timeProviderMock = CreateTimeProviderMock(borehole.Locked.Value.AddMinutes(1));
         boreholeLockService = new BoreholeLockService(context, new Mock<ILogger<BoreholeLockService>>().Object, timeProviderMock.Object);
 
-        await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(async () => await boreholeLockService.IsBoreholeLockedAsync(borehole.Id, EditorSubjectId));
+        Assert.AreEqual(true, await boreholeLockService.IsBoreholeLockedAsync(borehole.Id, EditorSubjectId));
     }
 
     [TestMethod]


### PR DESCRIPTION
Do not return UnauthorizedAccessExceptions inside the method, return a boolean indicating the lock status instead.

Working on #939 