### PR TITLE
Fix CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./data/minio:/data
     entrypoint: sh
-    command: -c 'mkdir -p /data/cannonflea && /usr/bin/minio server /data -console-address ":9002"'
+    command: -c 'mkdir -p /data/cannonflea && minio server /data -console-address ":9002"'
     ports:
       - 9000:9000
   db:

--- a/src/client/cypress/e2e/helpers/testHelpers.js
+++ b/src/client/cypress/e2e/helpers/testHelpers.js
@@ -257,7 +257,7 @@ export const loginAndResetState = () => {
       auth: bearerAuth(token),
     }).then(response => {
       response.body.data
-        .filter(id => id > 1009999) // max id in seed data.
+        .filter(id => id > 1002999) // max id in seed data.
         .forEach(id => {
           deleteBorehole(id);
         });

--- a/src/client/cypress/e2e/identifierFilter.cy.js
+++ b/src/client/cypress/e2e/identifierFilter.cy.js
@@ -108,7 +108,7 @@ describe("Tests for filtering data by identifier.", () => {
       .find('[role="option"]')
       .eq(1)
       .click({ force: true });
-    cy.get("tbody").children().should("have.length", 3);
+    cy.get("tbody").children().should("have.length", 2);
 
     cy.get('[data-cy="borehole-table"] thead .checkbox').click({ force: true });
     cy.contains("button", "Bulk editing").click({ force: true });


### PR DESCRIPTION
- Fixes bug where sometimes tests fail, when boreholes are not correctly reset in cy tests. (Introduced when reducing the amount of seeded boreholes).
- Fixes MinIO Startup command  => Problem introduced with MinIO Release: [RELEASE.2024-02-14T21-36-02Z](https://github.com/minio/minio/releases/tag/RELEASE.2024-02-14T21-36-02Z)