### PR TITLE
Add missing migration

### DIFF
--- a/src/api/BdmsContext.cs
+++ b/src/api/BdmsContext.cs
@@ -263,5 +263,11 @@ public class BdmsContext : DbContext
         modelBuilder.Entity<GroundwaterLevelMeasurement>().ToTable("groundwater_level_measurement").HasBaseType<Observation>();
 
         modelBuilder.Entity<FieldMeasurement>().ToTable("field_measurement").HasBaseType<Observation>();
+
+        modelBuilder.Entity<CasingElement>()
+            .HasOne(ce => ce.Kind)
+            .WithMany()
+            .HasForeignKey(ce => ce.KindId)
+            .OnDelete(DeleteBehavior.NoAction);
     }
 }

--- a/src/api/Migrations/20240306151944_AddMissingMigration.Designer.cs
+++ b/src/api/Migrations/20240306151944_AddMissingMigration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BDMS;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BDMS.Migrations
 {
     [DbContext(typeof(BdmsContext))]
-    partial class BdmsContextModelSnapshot : ModelSnapshot
+    [Migration("20240306151944_AddMissingMigration")]
+    partial class AddMissingMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/Migrations/20240306151944_AddMissingMigration.cs
+++ b/src/api/Migrations/20240306151944_AddMissingMigration.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BDMS.Migrations;
+
+/// <inheritdoc />
+public partial class AddMissingMigration : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_y_lv03",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: true,
+            oldClrType: typeof(int),
+            oldType: "integer");
+
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_y",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: true,
+            oldClrType: typeof(int),
+            oldType: "integer");
+
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_x_lv03",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: true,
+            oldClrType: typeof(int),
+            oldType: "integer");
+
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_x",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: true,
+            oldClrType: typeof(int),
+            oldType: "integer");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_y_lv03",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0,
+            oldClrType: typeof(int),
+            oldType: "integer",
+            oldNullable: true);
+
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_y",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0,
+            oldClrType: typeof(int),
+            oldType: "integer",
+            oldNullable: true);
+
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_x_lv03",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0,
+            oldClrType: typeof(int),
+            oldType: "integer",
+            oldNullable: true);
+
+        migrationBuilder.AlterColumn<int>(
+            name: "precision_location_x",
+            schema: "bdms",
+            table: "borehole",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0,
+            oldClrType: typeof(int),
+            oldType: "integer",
+            oldNullable: true);
+    }
+}


### PR DESCRIPTION
Adds a missing migrations for the changed nullability of precision attributes and fixes a problem, where when adding a new migration the delete behaviour "Cascade" was always added for casing elements.