### PR TITLE
Add viewer role when adding user

### DIFF
--- a/config/oidc-mock-users.json
+++ b/config/oidc-mock-users.json
@@ -1,8 +1,8 @@
 [
   {
-    "SubjectId":"sub_admin",
-    "Username":"admin",
-    "Password":"swissforages",
+    "SubjectId": "sub_admin",
+    "Username": "admin",
+    "Password": "swissforages",
     "Claims": [
       {
         "Type": "name",
@@ -37,9 +37,9 @@
     ]
   },
   {
-    "SubjectId":"sub_editor",
-    "Username":"editor",
-    "Password":"swissforages",
+    "SubjectId": "sub_editor",
+    "Username": "editor",
+    "Password": "swissforages",
     "Claims": [
       {
         "Type": "name",
@@ -59,6 +59,43 @@
       {
         "Type": "email",
         "Value": "editor.user@local.dev",
+        "ValueType": "string"
+      },
+      {
+        "Type": "email_verified",
+        "Value": "true",
+        "ValueType": "boolean"
+      },
+      {
+        "Type": "local_groups_claim",
+        "Value": "[\"boreholes_dev_group\"]",
+        "ValueType": "json"
+      }
+    ]
+  },
+  {
+    "SubjectId": "sub_viewer",
+    "Username": "viewer",
+    "Password": "swissforages",
+    "Claims": [
+      {
+        "Type": "name",
+        "Value": "Viewer User",
+        "ValueType": "string"
+      },
+      {
+        "Type": "family_name",
+        "Value": "User",
+        "ValueType": "string"
+      },
+      {
+        "Type": "given_name",
+        "Value": "Viewer",
+        "ValueType": "string"
+      },
+      {
+        "Type": "email",
+        "Value": "viewer.user@local.dev",
         "ValueType": "string"
       },
       {

--- a/src/api/Authentication/DatabaseAuthenticationClaimsTransformation.cs
+++ b/src/api/Authentication/DatabaseAuthenticationClaimsTransformation.cs
@@ -52,7 +52,19 @@ public class DatabaseAuthenticationClaimsTransformation : IClaimsTransformation
         if (subjectId is null)
             return null;
 
-        var user = dbContext.Users.SingleOrDefault(u => u.SubjectId == subjectId) ?? new User { SubjectId = subjectId, IsViewer = true };
+        var user = dbContext.Users.SingleOrDefault(u => u.SubjectId == subjectId) ?? new User
+        {
+            SubjectId = subjectId,
+            IsViewer = true,
+            WorkgroupRoles = new List<UserWorkgroupRole>
+            {
+                new UserWorkgroupRole
+                {
+                    WorkgroupId = 1, // Workgroup Default
+                    Role = Role.View,
+                },
+            },
+        };
         user.FirstName = principal.Claims.FirstOrDefault(c => c.Type == ClaimTypes.GivenName)?.Value ?? user.FirstName;
         user.LastName = principal.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Surname)?.Value ?? user.LastName;
         user.Name = $"{user.FirstName[0]}. {user.LastName}";

--- a/src/api/Models/User.cs
+++ b/src/api/Models/User.cs
@@ -65,7 +65,7 @@ public class User : IIdentifyable
     /// Gets or sets the WorkgroupRoles.
     /// </summary>
     public ICollection<UserWorkgroupRole> WorkgroupRoles { get; set; }
-     
+
     /// <summary>
     /// Gets the events.
     /// </summary>

--- a/src/api/Models/User.cs
+++ b/src/api/Models/User.cs
@@ -62,10 +62,10 @@ public class User : IIdentifyable
     public DateTime? DisabledAt { get; set; }
 
     /// <summary>
-    /// Gets the WorkgroupRoles.
+    /// Gets or sets the WorkgroupRoles.
     /// </summary>
-    public IEnumerable<UserWorkgroupRole> WorkgroupRoles { get; }
-
+    public ICollection<UserWorkgroupRole> WorkgroupRoles { get; set; }
+     
     /// <summary>
     /// Gets the events.
     /// </summary>


### PR DESCRIPTION
Bislang wurde ein User beim erstmaligen Login zwar erstellt, ihm waren jedoch keine Rollen zugewiesen. Für das legacy Api braucht es die aber. Ist bislang nicht aufgefallen, da wir in den cypress tests noch keine Tests mit Login in der Viewer Rolle (lediglich im Viewer Modus) hatten. Das werde ich mit dem Rückbau des Viewer-Modus anpassen.