### PR TITLE
Rename BoreholeFileUploadService

### DIFF
--- a/src/api/BoreholeFileCloudService.cs
+++ b/src/api/BoreholeFileCloudService.cs
@@ -7,9 +7,9 @@ using System.Security.Cryptography;
 namespace BDMS;
 
 /// <summary>
-/// Represents a service to upload borehole files to the cloud storage.
+/// Represents a service to manage borehole files in the cloud storage.
 /// </summary>
-public class BoreholeFileUploadService
+public class BoreholeFileCloudService
 {
     private readonly BdmsContext context;
     private readonly ILogger logger;
@@ -17,7 +17,7 @@ public class BoreholeFileUploadService
     private readonly IAmazonS3 s3Client;
     private readonly string bucketName;
 
-    public BoreholeFileUploadService(BdmsContext context, IConfiguration configuration, ILogger<BoreholeFileUploadService> logger, IHttpContextAccessor httpContextAccessor, IAmazonS3 s3Client)
+    public BoreholeFileCloudService(BdmsContext context, IConfiguration configuration, ILogger<BoreholeFileCloudService> logger, IHttpContextAccessor httpContextAccessor, IAmazonS3 s3Client)
     {
         this.logger = logger;
         this.httpContextAccessor = httpContextAccessor;

--- a/src/api/Controllers/BoreholeFileController.cs
+++ b/src/api/Controllers/BoreholeFileController.cs
@@ -2,7 +2,6 @@
 using BDMS.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 
@@ -14,14 +13,14 @@ public class BoreholeFileController : ControllerBase
 {
     private const int MaxFileSize = 210_000_000; // 1024 x 1024 x 200 = 209715200 bytes
     private readonly BdmsContext context;
-    private readonly BoreholeFileUploadService boreholeFileUploadService;
+    private readonly BoreholeFileCloudService boreholeFileCloudService;
     private readonly ILogger logger;
 
-    public BoreholeFileController(BdmsContext context, ILogger<BoreholeFileController> logger, BoreholeFileUploadService boreholeFileUploadService)
+    public BoreholeFileController(BdmsContext context, ILogger<BoreholeFileController> logger, BoreholeFileCloudService boreholeFileCloudService)
         : base()
     {
         this.logger = logger;
-        this.boreholeFileUploadService = boreholeFileUploadService;
+        this.boreholeFileCloudService = boreholeFileCloudService;
         this.context = context;
     }
 
@@ -44,7 +43,7 @@ public class BoreholeFileController : ControllerBase
 
         try
         {
-            var boreholeFile = await boreholeFileUploadService.UploadFileAndLinkToBorehole(file, boreholeId).ConfigureAwait(false);
+            var boreholeFile = await boreholeFileCloudService.UploadFileAndLinkToBorehole(file, boreholeId).ConfigureAwait(false);
             return Ok(boreholeFile);
         }
         catch (InvalidOperationException ex)
@@ -79,7 +78,7 @@ public class BoreholeFileController : ControllerBase
 
             if (boreholeFile?.File?.NameUuid == null) return NotFound($"File with id {boreholeFileId} not found.");
 
-            var fileBytes = await boreholeFileUploadService.GetObject(boreholeFile.File.NameUuid).ConfigureAwait(false);
+            var fileBytes = await boreholeFileCloudService.GetObject(boreholeFile.File.NameUuid).ConfigureAwait(false);
 
             return File(fileBytes, "application/octet-stream", boreholeFile.File.Name);
         }
@@ -112,8 +111,8 @@ public class BoreholeFileController : ControllerBase
             if (boreholeFile?.File?.NameUuid == null) return NotFound($"File with id {boreholeFileId} not found.");
 
             var fileUuid = boreholeFile.File.NameUuid.Replace(".pdf", "", StringComparison.OrdinalIgnoreCase);
-            var fileCount = await boreholeFileUploadService.CountDataExtractionObjects(fileUuid).ConfigureAwait(false);
-            var result = await boreholeFileUploadService.GetDataExtractionImageInfo(fileUuid, index).ConfigureAwait(false);
+            var fileCount = await boreholeFileCloudService.CountDataExtractionObjects(fileUuid).ConfigureAwait(false);
+            var result = await boreholeFileCloudService.GetDataExtractionImageInfo(fileUuid, index).ConfigureAwait(false);
 
             return Ok(new
             {
@@ -142,7 +141,7 @@ public class BoreholeFileController : ControllerBase
         try
         {
             var decodedImageName = Uri.UnescapeDataString($"dataextraction/{imageName}");
-            var fileBytes = await boreholeFileUploadService.GetObject(decodedImageName).ConfigureAwait(false);
+            var fileBytes = await boreholeFileCloudService.GetObject(decodedImageName).ConfigureAwait(false);
             return File(fileBytes, "image/png", decodedImageName);
         }
         catch (Exception ex)
@@ -204,7 +203,7 @@ public class BoreholeFileController : ControllerBase
             // If the file is not linked to any boreholes, delete it from the cloud storage and the database.
             if (file?.NameUuid != null && file.BoreholeFiles.Count == 0)
             {
-                await boreholeFileUploadService.DeleteObject(file.NameUuid).ConfigureAwait(false);
+                await boreholeFileCloudService.DeleteObject(file.NameUuid).ConfigureAwait(false);
                 context.Files.Remove(file);
                 await context.SaveChangesAsync().ConfigureAwait(false);
             }

--- a/src/api/Controllers/UploadController.cs
+++ b/src/api/Controllers/UploadController.cs
@@ -21,7 +21,7 @@ public class UploadController : ControllerBase
     private readonly ILogger logger;
     private readonly LocationService locationService;
     private readonly CoordinateService coordinateService;
-    private readonly BoreholeFileUploadService boreholeFileUploadService;
+    private readonly BoreholeFileCloudService boreholeFileCloudService;
     private readonly int sridLv95 = 2056;
     private readonly int sridLv03 = 21781;
     private readonly string nullOrEmptyMsg = "Field '{0}' is required.";
@@ -33,13 +33,13 @@ public class UploadController : ControllerBase
         MissingFieldFound = null,
     };
 
-    public UploadController(BdmsContext context, ILogger<UploadController> logger, LocationService locationService, CoordinateService coordinateService, BoreholeFileUploadService boreholeFileUploadService)
+    public UploadController(BdmsContext context, ILogger<UploadController> logger, LocationService locationService, CoordinateService coordinateService, BoreholeFileCloudService boreholeFileCloudService)
     {
         this.context = context;
         this.logger = logger;
         this.locationService = locationService;
         this.coordinateService = coordinateService;
-        this.boreholeFileUploadService = boreholeFileUploadService;
+        this.boreholeFileCloudService = boreholeFileCloudService;
     }
 
     /// <summary>
@@ -170,7 +170,7 @@ public class UploadController : ControllerBase
                     var attachmentFiles = attachments.Where(x => attachmentFileNames != null && attachmentFileNames.Contains(x.FileName.Replace(" ", "", StringComparison.InvariantCulture))).ToList();
                     foreach (var attachmentFile in attachmentFiles)
                     {
-                        await boreholeFileUploadService.UploadFileAndLinkToBorehole(attachmentFile, boreholeImport.Id).ConfigureAwait(false);
+                        await boreholeFileCloudService.UploadFileAndLinkToBorehole(attachmentFile, boreholeImport.Id).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/api/Program.cs
+++ b/src/api/Program.cs
@@ -102,7 +102,7 @@ builder.Services.AddApiVersioning(config =>
 
 builder.Services.AddScoped<LocationService>();
 builder.Services.AddScoped<CoordinateService>();
-builder.Services.AddScoped<BoreholeFileUploadService>();
+builder.Services.AddScoped<BoreholeFileCloudService>();
 builder.Services.AddSingleton<IAmazonS3>(sp =>
 {
     var s3ConfigSection = builder.Configuration.GetSection("S3");

--- a/tests/BoreholeFileCloudServiceTest.cs
+++ b/tests/BoreholeFileCloudServiceTest.cs
@@ -12,11 +12,11 @@ using static BDMS.Helpers;
 namespace BDMS;
 
 [TestClass]
-public class BoreholeFileUploadServiceTest
+public class BoreholeFileCloudServiceTest
 {
     private AmazonS3Client s3Client;
     private BdmsContext context;
-    private BoreholeFileUploadService boreholeFileUploadService;
+    private BoreholeFileCloudService boreholeFileUploadService;
     private string bucketName;
     private Models.User adminUser;
 
@@ -32,7 +32,7 @@ public class BoreholeFileUploadServiceTest
         contextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
         contextAccessorMock.Object.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, adminUser.SubjectId) }));
 
-        var loggerMock = new Mock<ILogger<BoreholeFileUploadService>>(MockBehavior.Strict);
+        var loggerMock = new Mock<ILogger<BoreholeFileCloudService>>(MockBehavior.Strict);
         loggerMock.Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()));
 
         var s3ClientMock = new AmazonS3Client(
@@ -45,7 +45,7 @@ public class BoreholeFileUploadServiceTest
                 UseHttp = configuration["S3:SECURE"] == "0",
             });
 
-        boreholeFileUploadService = new BoreholeFileUploadService(context, configuration, loggerMock.Object, contextAccessorMock.Object, s3ClientMock);
+        boreholeFileUploadService = new BoreholeFileCloudService(context, configuration, loggerMock.Object, contextAccessorMock.Object, s3ClientMock);
 
         bucketName = configuration["S3:BUCKET_NAME"].ToLowerInvariant();
         s3Client = s3ClientMock;

--- a/tests/Controllers/UploadControllerTest.cs
+++ b/tests/Controllers/UploadControllerTest.cs
@@ -49,13 +49,13 @@ public class UploadControllerTest
             ForcePathStyle = true,
             UseHttp = configuration["S3:SECURE"] == "0",
         });
-        var loggerBoreholeFileUploadService = new Mock<ILogger<BoreholeFileUploadService>>(MockBehavior.Strict);
+        var loggerBoreholeFileCloudService = new Mock<ILogger<BoreholeFileCloudService>>(MockBehavior.Strict);
         var contextAccessorMock = new Mock<IHttpContextAccessor>(MockBehavior.Strict);
         contextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
         contextAccessorMock.Object.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, context.Users.FirstOrDefault().SubjectId) }));
-        var boreholeFileUploadService = new BoreholeFileUploadService(context, configuration, loggerBoreholeFileUploadService.Object, contextAccessorMock.Object, s3ClientMock);
+        var boreholeFileCloudService = new BoreholeFileCloudService(context, configuration, loggerBoreholeFileCloudService.Object, contextAccessorMock.Object, s3ClientMock);
 
-        controller = new UploadController(context, loggerMock.Object, locationService, coordinateService, boreholeFileUploadService) { ControllerContext = GetControllerContextAdmin() };
+        controller = new UploadController(context, loggerMock.Object, locationService, coordinateService, boreholeFileCloudService) { ControllerContext = GetControllerContextAdmin() };
     }
 
     [TestCleanup]


### PR DESCRIPTION
Ich schlage vor, dass wir diesen Service umbenennen, da er nicht nur für den Upload zuständig ist, sondern für sämtliche S3-Interaktionen.