### PR TITLE
Use script instead of ga npm package

### DIFF
--- a/src/client/package.json
+++ b/src/client/package.json
@@ -59,7 +59,6 @@
     "react-dom": "19.1.0",
     "react-draggable": "4.4.6",
     "react-dropzone": "^14.2.3",
-    "react-ga4": "^2.1.0",
     "react-highlight-words": "^0.21.0",
     "react-hook-form": "^7.48.2",
     "react-i18next": "^13.5.0",

--- a/src/client/src/components/GoogleAnalytics.tsx
+++ b/src/client/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,30 @@
+import { FC, useEffect } from "react";
+
+interface GoogleAnalyticsProps {
+  id: string;
+}
+
+export const GoogleAnalytics: FC<GoogleAnalyticsProps> = ({ id }) => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+    document.head.appendChild(script);
+
+    const inlineScript = document.createElement("script");
+    inlineScript.innerHTML = `
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '${id}');
+    `;
+    document.head.appendChild(inlineScript);
+
+    return () => {
+      document.head.removeChild(script);
+      document.head.removeChild(inlineScript);
+    };
+  }, [id]);
+
+  return null;
+};

--- a/src/client/src/pages/detail/detailPage.tsx
+++ b/src/client/src/pages/detail/detailPage.tsx
@@ -6,6 +6,7 @@ import { Role } from "../../api/apiInterfaces.ts";
 import { useBorehole } from "../../api/borehole.ts";
 import { useCurrentUser } from "../../api/user.ts";
 import { SidePanelToggleButton } from "../../components/buttons/labelingButtons.tsx";
+import { GoogleAnalytics } from "../../components/GoogleAnalytics.tsx";
 import { FullPageCentered, LayoutBox, MainContentBox, SidebarBox } from "../../components/styledComponents.ts";
 import { useRequiredParams } from "../../hooks/useRequiredParams.ts";
 import { AnalyticsContext, AnalyticsContextProps } from "../../term/analyticsContext.tsx";
@@ -24,7 +25,7 @@ export const DetailPage: FC = () => {
   const { panelPosition, panelOpen, togglePanel } = useLabelingContext();
   const { editingEnabled, setEditingEnabled } = useContext(EditStateContext);
   const { showSaveBar } = useContext<SaveContextProps>(SaveContext);
-  const { sendAnalyticsEvent } = useContext<AnalyticsContextProps>(AnalyticsContext);
+  const { analyticsId } = useContext<AnalyticsContextProps>(AnalyticsContext);
   const { id } = useRequiredParams<{ id: string }>();
   const { data: borehole, isLoading } = useBorehole(parseInt(id));
   const { data: currentUser } = useCurrentUser();
@@ -32,10 +33,6 @@ export const DetailPage: FC = () => {
   useEffect(() => {
     setEditingEnabled(borehole?.locked !== null && borehole?.lockedById === currentUser?.id);
   }, [borehole?.locked, borehole?.lockedById, setEditingEnabled, currentUser?.id]);
-
-  useEffect(() => {
-    sendAnalyticsEvent();
-  }, [sendAnalyticsEvent]);
 
   useEffect(() => {
     if (borehole?.locked && borehole?.lockedById !== currentUser?.id) {
@@ -109,6 +106,7 @@ export const DetailPage: FC = () => {
           </Stack>
         </Suspense>
       </LayoutBox>
+      {analyticsId && <GoogleAnalytics id={analyticsId} />}
     </>
   );
 };

--- a/src/client/src/pages/overview/overviewPage.tsx
+++ b/src/client/src/pages/overview/overviewPage.tsx
@@ -3,7 +3,9 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useLocation } from "react-router-dom";
 import { Workgroup } from "../../api-lib/ReduxStateInterfaces.ts";
 import { AlertContext } from "../../components/alert/alertContext.tsx";
+import { GoogleAnalytics } from "../../components/GoogleAnalytics.tsx";
 import { LayoutBox, MainContentBox, SidebarBox } from "../../components/styledComponents.ts";
+import { AnalyticsContext, AnalyticsContextProps } from "../../term/analyticsContext.tsx";
 import MainSideNav from "./layout/mainSideNav.tsx";
 import { MapView } from "./layout/mapView.tsx";
 import { SideDrawer } from "./layout/sideDrawer.tsx";
@@ -22,6 +24,7 @@ export const OverviewPage = () => {
   const [sideDrawerContent, setSideDrawerContent] = useState(DrawerContentTypes.Filters);
   const [errorsResponse, setErrorsResponse] = useState<ErrorResponse | null>(null);
   const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+  const { analyticsId } = useContext<AnalyticsContextProps>(AnalyticsContext);
 
   const { showAlert } = useContext(AlertContext);
   const formMethods = useForm({ mode: "all", shouldUnregister: false });
@@ -63,28 +66,31 @@ export const OverviewPage = () => {
   }, [location.pathname]);
 
   return (
-    <LayoutBox>
-      <SidebarBox>
-        <MainSideNav
-          setWorkgroupId={setWorkgroupId}
-          setEnabledWorkgroups={setEnabledWorkgroups}
-          toggleDrawer={toggleSideDrawer}
-          drawerOpen={sideDrawerOpen}
-          setSideDrawerContent={setSideDrawerContent}
-          sideDrawerContent={sideDrawerContent}
-          errorsResponse={errorsResponse}
-          errorDialogOpen={errorDialogOpen}
-          setErrorDialogOpen={setErrorDialogOpen}
-        />
-      </SidebarBox>
-      <SideDrawer drawerOpen={sideDrawerOpen} drawerContent={sideDrawerComponentMap[sideDrawerContent]} />
-      <MainContentBox>
-        <MapView
-          displayErrorMessage={message => {
-            showAlert(message, "error");
-          }}
-        />
-      </MainContentBox>
-    </LayoutBox>
+    <>
+      <LayoutBox>
+        <SidebarBox>
+          <MainSideNav
+            setWorkgroupId={setWorkgroupId}
+            setEnabledWorkgroups={setEnabledWorkgroups}
+            toggleDrawer={toggleSideDrawer}
+            drawerOpen={sideDrawerOpen}
+            setSideDrawerContent={setSideDrawerContent}
+            sideDrawerContent={sideDrawerContent}
+            errorsResponse={errorsResponse}
+            errorDialogOpen={errorDialogOpen}
+            setErrorDialogOpen={setErrorDialogOpen}
+          />
+        </SidebarBox>
+        <SideDrawer drawerOpen={sideDrawerOpen} drawerContent={sideDrawerComponentMap[sideDrawerContent]} />
+        <MainContentBox>
+          <MapView
+            displayErrorMessage={message => {
+              showAlert(message, "error");
+            }}
+          />
+        </MainContentBox>
+      </LayoutBox>
+      {analyticsId && <GoogleAnalytics id={analyticsId} />}
+    </>
   );
 };

--- a/src/client/src/term/accept.tsx
+++ b/src/client/src/term/accept.tsx
@@ -15,7 +15,7 @@ interface Terms {
 
 export const AcceptTerms = ({ children }: { children: React.ReactNode }) => {
   const [hasAccepted, setHasAccepted] = useState(false);
-  const { setAnalyticsEnabled, sendAnalyticsEvent } = useContext<AnalyticsContextProps>(AnalyticsContext);
+  const { setAnalyticsEnabled } = useContext<AnalyticsContextProps>(AnalyticsContext);
   const [terms, setTerms] = useState<Terms>({ en: en, de: de, fr: fr, it: it });
   const [isFetching, setIsFetching] = useState(true);
   const { i18n } = useTranslation();
@@ -35,12 +35,6 @@ export const AcceptTerms = ({ children }: { children: React.ReactNode }) => {
       }
     });
   }, []);
-
-  useEffect(() => {
-    if (hasAccepted) {
-      sendAnalyticsEvent();
-    }
-  }, [hasAccepted, sendAnalyticsEvent]);
 
   const handleDialogClose = (analyticsEnabled: boolean) => {
     setAnalyticsEnabled(analyticsEnabled);

--- a/src/client/src/term/analyticsContext.tsx
+++ b/src/client/src/term/analyticsContext.tsx
@@ -1,15 +1,14 @@
 import { createContext, FC, PropsWithChildren, useCallback, useState } from "react";
-import ReactGA from "react-ga4";
 import { useSettings } from "../api/useSettings.ts";
 
 export interface AnalyticsContextProps {
   setAnalyticsEnabled: (analyticsEnabled: boolean) => void;
-  sendAnalyticsEvent: () => void;
+  analyticsId?: string;
 }
 
 export const AnalyticsContext = createContext<AnalyticsContextProps>({
   setAnalyticsEnabled: () => false,
-  sendAnalyticsEvent: () => {},
+  analyticsId: undefined,
 });
 
 export const AnalyticsProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -18,29 +17,16 @@ export const AnalyticsProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const handleSetAnalyticsEnabled = useCallback(
     (enabled: boolean) => {
-      if (enabled && settings?.googleAnalyticsTrackingId) {
-        setAnalyticsEnabled(true);
-        if (!ReactGA.isInitialized) {
-          ReactGA.initialize(settings?.googleAnalyticsTrackingId);
-        }
-      } else {
-        setAnalyticsEnabled(false);
-      }
+      setAnalyticsEnabled(Boolean(enabled && settings?.googleAnalyticsTrackingId));
     },
     [settings?.googleAnalyticsTrackingId],
   );
-
-  const sendAnalyticsEvent = useCallback(() => {
-    if (analyticsEnabled) {
-      ReactGA.send("pageview");
-    }
-  }, [analyticsEnabled]);
 
   return (
     <AnalyticsContext.Provider
       value={{
         setAnalyticsEnabled: handleSetAnalyticsEnabled,
-        sendAnalyticsEvent,
+        analyticsId: analyticsEnabled ? settings?.googleAnalyticsTrackingId : undefined,
       }}>
       {children}
     </AnalyticsContext.Provider>


### PR DESCRIPTION
Resolves #2035 

Zum Test hahb ich folgende Stellen überschreiben und dann das Skript im DOM gesehen:
```
export const AnalyticsProvider: FC<PropsWithChildren> = ({ children }) => {
  const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
  const settings = useSettings();

  const handleSetAnalyticsEnabled = useCallback(
    (enabled: boolean) => {
      setAnalyticsEnabled(Boolean(enabled)); // <-----------------
    },
    [settings?.googleAnalyticsTrackingId],
  );

  return (
    <AnalyticsContext.Provider
      value={{
        setAnalyticsEnabled: handleSetAnalyticsEnabled,
        analyticsId: analyticsEnabled ? "ABCDEF" : undefined, // <-----------------
      }}>
      {children}
    </AnalyticsContext.Provider>
  );
};
```
![image](https://github.com/user-attachments/assets/420d5fc9-dfce-4353-85da-4a814d70e650)
