### PR TITLE
Update gtag script

### DIFF
--- a/src/client/src/components/GoogleAnalytics.tsx
+++ b/src/client/src/components/GoogleAnalytics.tsx
@@ -14,7 +14,7 @@ export const GoogleAnalytics: FC<GoogleAnalyticsProps> = ({ id }) => {
     const inlineScript = document.createElement("script");
     inlineScript.innerHTML = `
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag(){window.dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', '${id}');
     `;


### PR DESCRIPTION
Working on #2035 

Bei Assets wird `window.dataLayer` verwendet statt nur `dataLayer`. Wir versuchen das hier auch mal, auch wenn es in der [Dokumentation](https://developers.google.com/tag-platform/devguides/datalayer) ohne `window` beschrieben ist.