### PR TITLE
Fix repeated Basic Auth password prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Added new GitHub Action workflow to add a release-candidate Docker image tag to a specific version.
 
+### Fixed
+- Fix repeated Basic Auth password prompts.
+
 ## v2.1.1431 - 2026-01-29
 
 ### Changed

--- a/src/client/src/api/fetchApiV2.ts
+++ b/src/client/src/api/fetchApiV2.ts
@@ -32,9 +32,11 @@ export async function fetchApiV2Base(
   const baseUrl = "/api/v2/";
   // @ts-expect-error redux store will not be typed, as it's going to be removed
   const authentication = store.getState().core_user.authentication;
-  let headers: Record<string, string> = {
-    Authorization: getAuthorizationHeader(authentication),
-  };
+  let headers: Record<string, string> = {};
+  // Only add Authorization header if user is authenticated (not in anonymous mode)
+  if (authentication !== null) {
+    headers.Authorization = getAuthorizationHeader(authentication);
+  }
   if (contentType) headers = { ...headers, "Content-Type": contentType };
   return await fetch(baseUrl + url, {
     method: method,


### PR DESCRIPTION
Working on #2510 

When a reverse proxy (e.g., INT view environment) is configured with an additional Basic Auth layer, the v2 API was sending `Authorization: Anonymous` header for unauthenticated requests. This interfered with the reverse proxy's Basic Auth mechanism, causing repeated login prompts.

The fix only adds the Authorization header when authentication is not null, matching the existing behavior in the v1 API ([api-lib/actions/index.js:9](https://github.com/swisstopo/swissgeol-boreholes-suite/blob/0e3484e2dcf502133e2d8c4cc4fc721480ff8f23/src/client/src/api-lib/actions/index.js#L9)) which already checks
`authentication !== null` before adding headers.