### PR TITLE
Conditional cypress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           TZ: Europe/Zurich
 
       - name: Cypress run (without recording)
-        if: secrets.CYPRESS_RECORD_KEY == ''
+        if: secrets.CYPRESS_RECORD_KEY == '' && matrix.containers == 1
         uses: cypress-io/github-action@84d178e4bbce871e23f2ffa3085898cde0e4f0ec # v7.1.2
         with:
           command: npx cypress run


### PR DESCRIPTION
- Dependabot can't trigger CI properly since dependabot does not get access to repo secrets (to protect against supply chain attacks), a workaround has been implemented. 
- The permissions have been clearly defined so dependabot can write into the PR and perform checks. This shouldn't open up any further attack vectors, since the CI does not run on PRs opened in this repo or by public forks.
- If cypress key is missing, do not run tests in paralllel containers, since all of them would run the full test suite each, costing us trillions of USD.