### PR TITLE
Set UID

### DIFF
--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -36,6 +36,6 @@ RUN npx license-checker --json --production \
   --customPath licenseCustomFormat.json \
   --out ./dist/license.json
 
-USER node
+USER 1000 # UID of user Node in `node:22-bookworm-slim`
 
 ENTRYPOINT ["node", "server.cjs"]


### PR DESCRIPTION
## Relates #2541 
- Set user in dockerfile by UID instead of name, as Kubernetes cannot determine if the user is root or not otherwise.