### PR TITLE
Comment was treated as part of the username

### DIFF
--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -34,7 +34,7 @@ RUN npm run build
 # Generate license and copyright notice for Node.js packages
 RUN npx license-checker --json --production \
   --customPath licenseCustomFormat.json \
-  --out ./dist/license.json \
+  --out ./dist/license.json
 
 # UID of user Node in `node:22-bookworm-slim`
 USER 1000


### PR DESCRIPTION
What i thought was a comment was actually treated as part of the username... goddamn it. Kubernetes error for reference

```
Warning  Failed     6s (x3 over 18s)  kubelet            spec.containers{swissgeol-boreholes-client}: Error: container has runAsNonRoot and image has non-numeric user (1000 # UID of user Node in `node), cannot verify user is non-root (pod: "swissgeol-boreholes-client-7ff4d99bf5-wbsxv_swissgeol-boreholes(16e2f4c2-a670-4200-900a-4e8abce935d3)", container: swissgeol-boreholes-client)
```