### PR TITLE
Upgrade OCR service to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Filters are now organized in new sections. Filters for attachments and LOG were added.
+- Upgraded swissgeol OCR service to version 1.1.4.
 
 ## v2.1.1568 - 2026-04-23
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     healthcheck:
       test: "curl --fail http://localhost:8000/health || exit 1"
   ocr:
-    image: ghcr.io/swisstopo/swissgeol-ocr-api:1.1.3
+    image: ghcr.io/swisstopo/swissgeol-ocr-api:1.1.4
     restart: unless-stopped
     ports:
       - "5052:8000"


### PR DESCRIPTION
Upgrades the OCR service to version 1.1.4. There are no breaking changes for the web app.

The data extraction service version was recently upgraded (https://github.com/swisstopo/swissgeol-boreholes-suite/commit/7bfec6b8fbdb2e0e5c901a8c39ae024c04712b2f) and is sufficiently up-to-date already.