### PR TITLE
Increase resource limits for dataextraction api

### DIFF
--- a/charts/swissgeol-boreholes/Chart.yaml
+++ b/charts/swissgeol-boreholes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: swissgeol-boreholes
 description: Borehole Data Management System
 type: application
-version: 0.10.4
+version: 0.10.5
 icon: https://raw.githubusercontent.com/swisstopo/swissgeol-boreholes-suite/main/src/client/public/favicon.ico
 appVersion: "v2.1.1431"
 home: https://www.swissgeol.ch/en

--- a/charts/swissgeol-boreholes/templates/dataextraction-api.yaml
+++ b/charts/swissgeol-boreholes/templates/dataextraction-api.yaml
@@ -63,7 +63,7 @@ spec:
               ephemeral-storage: 2Gi
             limits:
               cpu: 1500m
-              memory: 2Gi
+              memory: 4Gi
               ephemeral-storage: 4Gi
           securityContext:
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Dataextraction API in version 1.0.162 was termined because it tried to use more memory than was allowed.