### PR TITLE
Disable raw HTML parsing in terms markdown

### DIFF
--- a/src/client/src/pages/settings/termSettings.jsx
+++ b/src/client/src/pages/settings/termSettings.jsx
@@ -208,7 +208,7 @@ class TermSettings extends React.Component {
               {t("preview")}
             </div>
           </div>
-          <Markdown>{this.state[this.state.lang]}</Markdown>
+          <Markdown options={{ disableParsingRawHTML: true }}>{this.state[this.state.lang]}</Markdown>
         </div>
       </div>
     );

--- a/src/client/src/term/markdownWrapper.tsx
+++ b/src/client/src/term/markdownWrapper.tsx
@@ -17,7 +17,7 @@ export const MarkdownWrapper = ({ markdownContent }: { markdownContent: string }
   return (
     <div>
       <div style={{ display: isRendered ? "block" : "none" }}>
-        <Markdown>{markdownContent}</Markdown>
+        <Markdown options={{ disableParsingRawHTML: true }}>{markdownContent}</Markdown>
       </div>
     </div>
   );


### PR DESCRIPTION
Render the Terms of Service strictly as markdown so embedded HTML in admin-edited content is shown as text.