### PR TITLE
Re-add release candidate action

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,38 @@
+name: Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: "Source version to tag (e.g., 2.1.1427)"
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  add-release-candidate-tag:
+    runs-on: ubuntu-latest
+    name: Add RC tag to Docker images
+
+    steps:
+      - name: Set environment variables
+        run: |
+          echo BASE_IMAGE_NAME=$REGISTRY/$(echo ${GITHUB_REPOSITORY,,}) >> $GITHUB_ENV
+          echo SOURCE_TAG=v${{ github.event.inputs.VERSION }} >> $GITHUB_ENV
+          echo RC_TAG=v${{ github.event.inputs.VERSION }}-rc >> $GITHUB_ENV
+
+      - name: Log in to the GitHub container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull, tag with RC suffix and push Docker images
+        run: |
+          for image in api-legacy api client view-sync extern-sync; do
+            docker pull ${BASE_IMAGE_NAME}-${image}:${SOURCE_TAG}
+            docker tag ${BASE_IMAGE_NAME}-${image}:${SOURCE_TAG} ${BASE_IMAGE_NAME}-${image}:${RC_TAG}
+            docker push ${BASE_IMAGE_NAME}-${image}:${RC_TAG}
+          done


### PR DESCRIPTION
The IaC-based INT deployment is not yet ready, so this action is restored as a temporary measure.
It will be removed again once the IaC deployment is in place.

#2577