### PR TITLE
Helm adjustments

### DIFF
--- a/charts/swissgeol-boreholes-extern-sync/templates/secrets.yaml
+++ b/charts/swissgeol-boreholes-extern-sync/templates/secrets.yaml
@@ -5,21 +5,27 @@
 {{- end }}
 {{- $sourceConn := "" }}
 {{- if .Values.db.source.host }}
+  {{- if not (and .Values.db.source.name .Values.db.source.username .Values.db.source.password) }}
+    {{- fail "db.source.host is set but db.source.name, db.source.username and db.source.password are also required. Supply all of them via --set, or omit db.source.host to reuse the existing Secret." }}
+  {{- end }}
   {{- $sourceConn = printf "Host=%s;Port=%s;Database=%s;Username=%s;Password=%s"
     .Values.db.source.host
     (.Values.db.source.port | default "5432" | toString)
-    (.Values.db.source.name | default "CHANGE_ME")
-    (.Values.db.source.username | default "CHANGE_ME")
-    (.Values.db.source.password | default "CHANGE_ME") }}
+    .Values.db.source.name
+    .Values.db.source.username
+    .Values.db.source.password }}
 {{- end }}
 {{- $targetConn := "" }}
 {{- if .Values.db.target.host }}
+  {{- if not (and .Values.db.target.name .Values.db.target.username .Values.db.target.password) }}
+    {{- fail "db.target.host is set but db.target.name, db.target.username and db.target.password are also required. Supply all of them via --set, or omit db.target.host to reuse the existing Secret." }}
+  {{- end }}
   {{- $targetConn = printf "Host=%s;Port=%s;Database=%s;Username=%s;Password=%s"
     .Values.db.target.host
     (.Values.db.target.port | default "5432" | toString)
-    (.Values.db.target.name | default "CHANGE_ME")
-    (.Values.db.target.username | default "CHANGE_ME")
-    (.Values.db.target.password | default "CHANGE_ME") }}
+    .Values.db.target.name
+    .Values.db.target.username
+    .Values.db.target.password }}
 {{- end }}
 apiVersion: v1
 kind: Secret
@@ -28,17 +34,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-{{- if $sourceConn }}
-  sourceDatabaseConnectionString: {{ $sourceConn | b64enc | quote }}
-{{- else if (and $existing (hasKey $existing "sourceDatabaseConnectionString")) }}
-  sourceDatabaseConnectionString: {{ index $existing "sourceDatabaseConnectionString" }}
-{{- else }}
-  {{ fail "Required secret key \"sourceDatabaseConnectionString\" is not set. Supply db.source.host (and related fields) via --set, or pre-populate sourceDatabaseConnectionString in the existing Secret before upgrading." }}
-{{- end }}
-{{- if $targetConn }}
-  targetDatabaseConnectionString: {{ $targetConn | b64enc | quote }}
-{{- else if (and $existing (hasKey $existing "targetDatabaseConnectionString")) }}
-  targetDatabaseConnectionString: {{ index $existing "targetDatabaseConnectionString" }}
-{{- else }}
-  {{ fail "Required secret key \"targetDatabaseConnectionString\" is not set. Supply db.target.host (and related fields) via --set, or pre-populate targetDatabaseConnectionString in the existing Secret before upgrading." }}
-{{- end }}
+  sourceDatabaseConnectionString: {{ include "resolve-secret" (dict "override" $sourceConn "existing" $existing "key" "sourceDatabaseConnectionString" "valuesPath" "db.source.host") | quote }}
+  targetDatabaseConnectionString: {{ include "resolve-secret" (dict "override" $targetConn "existing" $existing "key" "targetDatabaseConnectionString" "valuesPath" "db.target.host") | quote }}

--- a/charts/swissgeol-boreholes/templates/secrets.yaml
+++ b/charts/swissgeol-boreholes/templates/secrets.yaml
@@ -48,9 +48,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-{{- if $existingBasicAuth }}
+{{- if and .Values.auth.basicAuthUsername .Values.auth.basicAuthPassword }}
+  users: {{ htpasswd .Values.auth.basicAuthUsername .Values.auth.basicAuthPassword | b64enc | quote }}
+{{- else if (and $existingBasicAuth (hasKey $existingBasicAuth.data "users")) }}
   users: {{ index $existingBasicAuth.data "users" }}
 {{- else }}
-  users: {{ htpasswd (default "admin" .Values.auth.basicAuthUsername) (default "CHANGE_ME" .Values.auth.basicAuthPassword) | b64enc | quote }}
+  {{- fail "Basic auth is enabled but no credentials are available. Supply both on first deploy via --set auth.basicAuthUsername=<user> --set auth.basicAuthPassword=<password>, or pre-populate the 'users' key in the existing <release>-basic-auth-secret Secret before upgrading." }}
 {{- end }}
 {{- end }}

--- a/charts/swissgeol-boreholes/values.schema.json
+++ b/charts/swissgeol-boreholes/values.schema.json
@@ -84,24 +84,7 @@
           "type": ["string", "null"],
           "minLength": 1
         }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "basicAuthEnabled": { "const": true }
-            },
-            "required": ["basicAuthEnabled"]
-          },
-          "then": {
-            "required": ["basicAuthUsername", "basicAuthPassword"],
-            "properties": {
-              "basicAuthUsername": { "type": "string", "minLength": 1 },
-              "basicAuthPassword": { "type": "string", "minLength": 1 }
-            }
-          }
-        }
-      ]
+      }
     },
 
     "database": {

--- a/environments/int/boreholes-view.values.yaml
+++ b/environments/int/boreholes-view.values.yaml
@@ -2,3 +2,5 @@
 # Applied on top of boreholes.values.yaml.
 app:
   domain: int-view-boreholes.swissgeol.ch
+auth:
+  basicAuthEnabled: true

--- a/environments/int/boreholes-view.values.yaml
+++ b/environments/int/boreholes-view.values.yaml
@@ -4,3 +4,4 @@ app:
   domain: int-view-boreholes.swissgeol.ch
 auth:
   basicAuthEnabled: true
+  anonymousModeEnabled: true

--- a/environments/prod/boreholes-view.values.yaml
+++ b/environments/prod/boreholes-view.values.yaml
@@ -2,3 +2,5 @@
 # Applied on top of boreholes.values.yaml.
 app:
   domain: boreholes.swissgeol.ch
+auth:
+  anonymousModeEnabled: true


### PR DESCRIPTION
  - Basic auth was lost in the Helm overhaul. This restores it. Enabled basic auth for the `int view` deployment
  - Enabling basic auth without credentials now fails the deploy loudly instead of silently provisioning default admin/CHANGE_ME credentials
  - Relax the values schema so deploy is allowed without explicitly passing basic auth information every time
  - Adjust extern-sync secrets the same way as existing secrets. It also now fails loudly and shares the common secret-resolution path.
