### PR TITLE
Enable save for autocorrected lithologies

### DIFF
--- a/src/client/src/pages/detail/form/stratigraphy/components/lithologyTable/useLithologyTableState.test.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/components/lithologyTable/useLithologyTableState.test.ts
@@ -93,6 +93,18 @@ describe("useLithologyTableState", () => {
       const first = result.current.tmpLithologies.find(l => l.id === 1)!;
       expect(first.toDepth).toBe(10);
       expect(first.isAutoCorrected).toBe(true);
+      expect(result.current.hasUnsavedChanges).toBe(true);
+    });
+
+    it("does not flag unsaved changes when input lithologies need no correction", () => {
+      const { result } = renderState({
+        lithologies: [
+          lithology({ id: 1, fromDepth: 0, toDepth: 50 }),
+          lithology({ id: 2, fromDepth: 50, toDepth: 100 }),
+        ],
+      });
+      expect(result.current.tmpLithologies.every(l => !l.isAutoCorrected)).toBe(true);
+      expect(result.current.hasUnsavedChanges).toBe(false);
     });
 
     it("fills lithology gaps with empty auto-corrected lithologies", () => {
@@ -108,6 +120,7 @@ describe("useLithologyTableState", () => {
       expect(gapFiller).toBeDefined();
       expect(gapFiller!.id).toBe(0); // new, unsaved
       expect(gapFiller!.isAutoCorrected).toBe(true);
+      expect(result.current.hasUnsavedChanges).toBe(true);
     });
 
     it("introduces depth boundaries from descriptions even when no lithology owns them", () => {

--- a/src/client/src/pages/detail/form/stratigraphy/components/lithologyTable/useLithologyTableState.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/components/lithologyTable/useLithologyTableState.ts
@@ -80,7 +80,7 @@ export const useLithologyTableState = (
     setTmpLithologies(cleanLithologies);
     setTmpLithologicalDescriptions(cleanLithologicalDescriptions);
     setTmpFaciesDescriptions(cleanFaciesDescriptions);
-    setHasUnsavedChanges(false);
+    setHasUnsavedChanges(cleanLithologies.some(l => l.isAutoCorrected));
   };
 
   if (seedInputHash !== seededInputHash) {


### PR DESCRIPTION
Working on #2753

Save-Button sollte aktiv sein, wenn autokorrigierte Lithologien vorhanden sind, so dass die User die Korrekturen direkt speichern können.