### PR TITLE
Drag to pan on main area

### DIFF
--- a/src/client/src/pages/detail/form/stratigraphy/chronostratigraphy/chronostratigraphyPanel.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/chronostratigraphy/chronostratigraphyPanel.jsx
@@ -5,19 +5,14 @@ import { NavigationChild } from "../navigation/NavigationChild.tsx";
 import { NavigationContainer } from "../navigation/NavigationContainer.tsx";
 import { NavigationLens } from "../navigation/NavigationLens.tsx";
 import { Scale } from "../navigation/Scale.tsx";
-import { useLithostratigraphies } from "../stratigraphy.ts";
 import ChronostratigraphyEditProfile from "./chronostratigraphyEditProfile.jsx";
 
 const ChronostratigraphyPanel = ({ stratigraphyId }) => {
-  const { data: layers } = useLithostratigraphies(stratigraphyId);
   const { t } = useTranslation();
-
-  const layerCount = layers?.length ?? 0;
-  const minHeight = Math.max(500, (layerCount + 1) * 150);
 
   return (
     <NavigationContainer
-      sx={{ gap: "0.5em", minHeight: minHeight + "px" }}
+      sx={{ gap: "0.5em", minHeight: "65vh", height: "100%" }}
       renderItems={(navState, setNavState) => {
         return (
           <>

--- a/src/client/src/pages/detail/form/stratigraphy/layerCard.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/layerCard.jsx
@@ -45,7 +45,12 @@ const LayerCard = ({
   const [cardState, setCardState] = useState(null);
   const { editingEnabled } = useContext(EditStateContext);
 
-  const minPixelHeightForDepthLabels = 65;
+  // Show the from/to depth labels only once the cell is tall enough that the center label and the
+  // two depth labels do not overlap. Below the center-label threshold, even the center text hides
+  // so very thin cells become pure colored bands.
+  const minPixelHeightForDepthLabels = 120;
+  const minPixelHeightForCenterLabel = 24;
+  const showCenterLabel = height >= minPixelHeightForCenterLabel;
 
   useEffect(() => {
     setCardState(prevState => {
@@ -299,7 +304,7 @@ const LayerCard = ({
                 borderRight: "1px solid rgba(0, 0, 0, 0.12)",
                 padding: "0 1rem",
               }}>
-              {[State.DISPLAY, State.EDITABLE].includes(cardState) && (
+              {[State.DISPLAY, State.EDITABLE].includes(cardState) && showCenterLabel && (
                 <Typography sx={{ textAlign: "center" }}>{selectedItem?.label ?? "-"}</Typography>
               )}
               {State.EDITING === cardState && (

--- a/src/client/src/pages/detail/form/stratigraphy/lithostratigraphy/lithostratigraphyPanel.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithostratigraphy/lithostratigraphyPanel.jsx
@@ -4,20 +4,15 @@ import { NavigationChild } from "../navigation/NavigationChild.tsx";
 import { NavigationContainer } from "../navigation/NavigationContainer.tsx";
 import { NavigationLens } from "../navigation/NavigationLens.tsx";
 import { Scale } from "../navigation/Scale.tsx";
-import { useLithostratigraphies } from "../stratigraphy.ts";
 import LithostratigraphyEditProfile from "./lithostratigraphyEditProfile.jsx";
 import LithostratigraphyViewProfile from "./lithostratigraphyViewProfile.jsx";
 
 const LithostratigraphyPanel = ({ stratigraphyId }) => {
-  const { data: layers } = useLithostratigraphies(stratigraphyId);
   const { t } = useTranslation();
-
-  const layerCount = layers?.length ?? 0;
-  const minHeight = Math.max(500, (layerCount + 1) * 150);
 
   return (
     <NavigationContainer
-      sx={{ gap: "0.5em", minHeight: minHeight + "px" }}
+      sx={{ gap: "0.5em", minHeight: "65vh", height: "100%" }}
       renderItems={(navState, setNavState) => {
         return (
           <>

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/NavigationContainer.tsx
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/NavigationContainer.tsx
@@ -31,7 +31,7 @@ export const NavigationContainer: FC<NavigationContainerProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   useTypedResizeObserver(containerRef, entry => setNavState(prev => prev.setHeight(entry.contentRect.height)));
 
-  const { onPointerDown, isDragging } = useDragPan({ navState, setNavState, containerRef });
+  const { onPointerDown, isDragging, isPannable } = useDragPan({ navState, setNavState, containerRef });
 
   const handleOnWheel = (event: WheelEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -63,7 +63,14 @@ export const NavigationContainer: FC<NavigationContainerProps> = ({
     <Stack
       ref={containerRef}
       direction="row"
-      sx={{ flex: "1", overflowX: "auto", cursor: isDragging ? "grabbing" : "grab", ...sx }}
+      sx={{
+        flex: "1",
+        overflowX: "auto",
+        cursor: isPannable ? (isDragging ? "grabbing" : "grab") : "default",
+        userSelect: "none",
+        touchAction: "none",
+        ...sx,
+      }}
       onWheel={handleOnWheel}
       onPointerDown={onPointerDown}>
       {renderItems(navState, setNavState)}

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/NavigationContainer.tsx
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/NavigationContainer.tsx
@@ -3,6 +3,7 @@ import { Stack } from "@mui/material";
 import { SxProps, Theme } from "@mui/material/styles";
 import { clamp } from "./clamp.ts";
 import { NavState } from "./navState.ts";
+import { useDragPan } from "./useDragPan.ts";
 import { useTypedResizeObserver } from "./useTypedResizeObserver.ts";
 
 interface NavigationContainerProps {
@@ -29,6 +30,8 @@ export const NavigationContainer: FC<NavigationContainerProps> = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   useTypedResizeObserver(containerRef, entry => setNavState(prev => prev.setHeight(entry.contentRect.height)));
+
+  const { onPointerDown, isDragging } = useDragPan({ navState, setNavState, containerRef });
 
   const handleOnWheel = (event: WheelEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -57,7 +60,12 @@ export const NavigationContainer: FC<NavigationContainerProps> = ({
   }, []);
 
   return (
-    <Stack ref={containerRef} direction="row" sx={{ flex: "1", overflowX: "auto", ...sx }} onWheel={handleOnWheel}>
+    <Stack
+      ref={containerRef}
+      direction="row"
+      sx={{ flex: "1", overflowX: "auto", cursor: isDragging ? "grabbing" : "grab", ...sx }}
+      onWheel={handleOnWheel}
+      onPointerDown={onPointerDown}>
       {renderItems(navState, setNavState)}
     </Stack>
   );

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/NavigationContainer.tsx
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/NavigationContainer.tsx
@@ -32,6 +32,8 @@ export const NavigationContainer: FC<NavigationContainerProps> = ({
   useTypedResizeObserver(containerRef, entry => setNavState(prev => prev.setHeight(entry.contentRect.height)));
 
   const { onPointerDown, isDragging, isPannable } = useDragPan({ navState, setNavState, containerRef });
+  const panCursor = isDragging ? "grabbing" : "grab";
+  const cursor = isPannable ? panCursor : "default";
 
   const handleOnWheel = (event: WheelEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -66,7 +68,7 @@ export const NavigationContainer: FC<NavigationContainerProps> = ({
       sx={{
         flex: "1",
         overflowX: "auto",
-        cursor: isPannable ? (isDragging ? "grabbing" : "grab") : "default",
+        cursor,
         userSelect: "none",
         touchAction: "none",
         ...sx,

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.test.tsx
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { Dispatch, SetStateAction, useCallback, useRef, useState } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NavState } from "./navState.ts";
 import { useDragPan } from "./useDragPan.ts";
 
@@ -40,11 +40,8 @@ const TestHarness = ({ initial, onChange }: TestHarnessProps) => {
   );
 };
 
-// jsdom doesn't implement Element.setPointerCapture; stub it so the hook can call it without throwing.
-const stubPointerCapture = () => {
-  Element.prototype.setPointerCapture = vi.fn();
-  Element.prototype.releasePointerCapture = vi.fn();
-};
+// jsdom doesn't implement Element.setPointerCapture/releasePointerCapture; assign no-op fns so the
+// hook can call them without throwing. Each test gets a fresh vi.fn via beforeEach.
 
 // jsdom's PointerEvent ignores `pointerId` and `pageY` in the init dict, so we set them
 // after construction via defineProperty before dispatching.
@@ -55,17 +52,21 @@ const dispatchPointer = (target: Element, type: string, pointerId: number, pageY
   fireEvent(target, event);
 };
 
+// baseNavState: height=500, maxHeader=0, lensSize=50, maxContent=100 -> pixelPerMeter = 10.
+
 describe("useDragPan", () => {
+  beforeEach(() => {
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
   afterEach(() => cleanup());
 
   it("starts not dragging", () => {
-    stubPointerCapture();
     render(<TestHarness initial={baseNavState()} />);
     expect(screen.getByTestId("container").getAttribute("data-dragging")).toBe("false");
   });
 
   it("sets isDragging on pointerDown and clears it on pointerUp", () => {
-    stubPointerCapture();
     render(<TestHarness initial={baseNavState()} />);
     const container = screen.getByTestId("container");
     dispatchPointer(container, "pointerdown", 1, 100);
@@ -75,43 +76,38 @@ describe("useDragPan", () => {
   });
 
   it("updates lensStart proportional to pointer-move deltaY and pixelPerMeter", () => {
-    stubPointerCapture();
     const changes: NavState[] = [];
     render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
     const container = screen.getByTestId("container");
-    // pixelPerMeter = (500 - 0) / 50 = 10
     dispatchPointer(container, "pointerdown", 1, 200);
     dispatchPointer(container, "pointermove", 1, 150);
-    // Dragged 50 px upward; lensStart should move down by 50/10 = 5 meters
-    const latest = changes.at(-1);
-    expect(latest?.lensStart).toBeCloseTo(5);
+    // Dragged 50 px upward; lensStart should move down by 50/10 = 5 meters.
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.at(-1)?.lensStart).toBeCloseTo(5);
   });
 
   it("clamps lensStart at 0 when dragging beyond the top", () => {
-    stubPointerCapture();
     const changes: NavState[] = [];
     render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
     const container = screen.getByTestId("container");
     dispatchPointer(container, "pointerdown", 1, 0);
     dispatchPointer(container, "pointermove", 1, 10000);
-    const latest = changes.at(-1);
-    expect(latest?.lensStart).toBe(0);
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.at(-1)?.lensStart).toBe(0);
   });
 
   it("clamps lensStart at maxContent minus lensSize when dragging beyond the bottom", () => {
-    stubPointerCapture();
     const changes: NavState[] = [];
     render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
     const container = screen.getByTestId("container");
     dispatchPointer(container, "pointerdown", 1, 10000);
     dispatchPointer(container, "pointermove", 1, 0);
-    const latest = changes.at(-1);
     // maxContent (100) - lensSize (50) = 50
-    expect(latest?.lensStart).toBe(50);
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.at(-1)?.lensStart).toBe(50);
   });
 
   it("clears isDragging on pointerCancel", () => {
-    stubPointerCapture();
     render(<TestHarness initial={baseNavState()} />);
     const container = screen.getByTestId("container");
     dispatchPointer(container, "pointerdown", 1, 100);

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.test.tsx
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { Dispatch, SetStateAction, useCallback, useRef, useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NavState } from "./navState.ts";
+import { useDragPan } from "./useDragPan.ts";
+
+const baseNavState = () =>
+  new NavState({ height: 500, rawLensSize: 50, contentHeights: { c: 100 }, headerHeights: { h: 0 } });
+
+interface TestHarnessProps {
+  initial: NavState;
+  onChange?: (next: NavState) => void;
+}
+
+const TestHarness = ({ initial, onChange }: TestHarnessProps) => {
+  const [state, setState] = useState<NavState>(initial);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const setNavState: Dispatch<SetStateAction<NavState>> = useCallback(
+    updater => {
+      setState(prev => {
+        const next = updater instanceof Function ? updater(prev) : updater;
+        onChange?.(next);
+        return next;
+      });
+    },
+    [onChange],
+  );
+
+  const { onPointerDown, isDragging } = useDragPan({ navState: state, setNavState, containerRef });
+
+  return (
+    <div
+      ref={containerRef}
+      onPointerDown={onPointerDown}
+      data-testid="container"
+      data-dragging={isDragging ? "true" : "false"}
+    />
+  );
+};
+
+// jsdom doesn't implement Element.setPointerCapture; stub it so the hook can call it without throwing.
+const stubPointerCapture = () => {
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+};
+
+// jsdom's PointerEvent ignores `pointerId` and `pageY` in the init dict, so we set them
+// after construction via defineProperty before dispatching.
+const dispatchPointer = (target: Element, type: string, pointerId: number, pageY: number) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  Object.defineProperty(event, "pageY", { value: pageY });
+  fireEvent(target, event);
+};
+
+describe("useDragPan", () => {
+  afterEach(() => cleanup());
+
+  it("starts not dragging", () => {
+    stubPointerCapture();
+    render(<TestHarness initial={baseNavState()} />);
+    expect(screen.getByTestId("container").getAttribute("data-dragging")).toBe("false");
+  });
+
+  it("sets isDragging on pointerDown and clears it on pointerUp", () => {
+    stubPointerCapture();
+    render(<TestHarness initial={baseNavState()} />);
+    const container = screen.getByTestId("container");
+    dispatchPointer(container, "pointerdown", 1, 100);
+    expect(container.getAttribute("data-dragging")).toBe("true");
+    dispatchPointer(container, "pointerup", 1, 100);
+    expect(container.getAttribute("data-dragging")).toBe("false");
+  });
+
+  it("updates lensStart proportional to pointer-move deltaY and pixelPerMeter", () => {
+    stubPointerCapture();
+    const changes: NavState[] = [];
+    render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
+    const container = screen.getByTestId("container");
+    // pixelPerMeter = (500 - 0) / 50 = 10
+    dispatchPointer(container, "pointerdown", 1, 200);
+    dispatchPointer(container, "pointermove", 1, 150);
+    // Dragged 50 px upward; lensStart should move down by 50/10 = 5 meters
+    const latest = changes.at(-1);
+    expect(latest?.lensStart).toBeCloseTo(5);
+  });
+
+  it("clamps lensStart at 0 when dragging beyond the top", () => {
+    stubPointerCapture();
+    const changes: NavState[] = [];
+    render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
+    const container = screen.getByTestId("container");
+    dispatchPointer(container, "pointerdown", 1, 0);
+    dispatchPointer(container, "pointermove", 1, 10000);
+    const latest = changes.at(-1);
+    expect(latest?.lensStart).toBe(0);
+  });
+
+  it("clamps lensStart at maxContent minus lensSize when dragging beyond the bottom", () => {
+    stubPointerCapture();
+    const changes: NavState[] = [];
+    render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
+    const container = screen.getByTestId("container");
+    dispatchPointer(container, "pointerdown", 1, 10000);
+    dispatchPointer(container, "pointermove", 1, 0);
+    const latest = changes.at(-1);
+    // maxContent (100) - lensSize (50) = 50
+    expect(latest?.lensStart).toBe(50);
+  });
+
+  it("clears isDragging on pointerCancel", () => {
+    stubPointerCapture();
+    render(<TestHarness initial={baseNavState()} />);
+    const container = screen.getByTestId("container");
+    dispatchPointer(container, "pointerdown", 1, 100);
+    expect(container.getAttribute("data-dragging")).toBe("true");
+    dispatchPointer(container, "pointercancel", 1, 100);
+    expect(container.getAttribute("data-dragging")).toBe("false");
+  });
+});

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.test.tsx
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.test.tsx
@@ -80,10 +80,10 @@ describe("useDragPan", () => {
     render(<TestHarness initial={baseNavState()} onChange={s => changes.push(s)} />);
     const container = screen.getByTestId("container");
     dispatchPointer(container, "pointerdown", 1, 200);
-    dispatchPointer(container, "pointermove", 1, 150);
-    // Dragged 50 px upward; lensStart should move down by 50/10 = 5 meters.
+    dispatchPointer(container, "pointermove", 1, 195);
+    // Dragged 5 px upward; with 2x speed multiplier, lensStart moves down by (5/10)*2 = 1 meter.
     expect(changes.length).toBeGreaterThan(0);
-    expect(changes.at(-1)?.lensStart).toBeCloseTo(5);
+    expect(changes.at(-1)?.lensStart).toBeCloseTo(1);
   });
 
   it("clamps lensStart at 0 when dragging beyond the top", () => {
@@ -105,6 +105,18 @@ describe("useDragPan", () => {
     // maxContent (100) - lensSize (50) = 50
     expect(changes.length).toBeGreaterThan(0);
     expect(changes.at(-1)?.lensStart).toBe(50);
+  });
+
+  it("is a no-op when the full content already fits in the lens (nothing to pan to)", () => {
+    const changes: NavState[] = [];
+    // maxContent = lensSize (raw=50, contentHeights also 50): nothing to pan to.
+    const fitting = new NavState({ height: 500, rawLensSize: 50, contentHeights: { c: 50 }, headerHeights: { h: 0 } });
+    render(<TestHarness initial={fitting} onChange={s => changes.push(s)} />);
+    const container = screen.getByTestId("container");
+    dispatchPointer(container, "pointerdown", 1, 100);
+    expect(container.getAttribute("data-dragging")).toBe("false");
+    dispatchPointer(container, "pointermove", 1, 50);
+    expect(changes.length).toBe(0);
   });
 
   it("clears isDragging on pointerCancel", () => {

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
@@ -1,0 +1,87 @@
+import {
+  Dispatch,
+  PointerEventHandler,
+  RefObject,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { clamp } from "./clamp.ts";
+import { NavState } from "./navState.ts";
+
+interface UseDragPanOptions {
+  navState: NavState;
+  setNavState: Dispatch<SetStateAction<NavState>>;
+  containerRef: RefObject<HTMLElement | null>;
+}
+
+interface UseDragPanResult {
+  onPointerDown: PointerEventHandler<HTMLElement>;
+  isDragging: boolean;
+}
+
+interface DragOrigin {
+  pointerId: number;
+  startPageY: number;
+  startLensStart: number;
+}
+
+// Lifts the lens-overview drag-pan behavior up to any scrollable container. Pointer-move
+// updates lensStart inversely to deltaY (drag down -> lens moves up, matching the "grab the
+// page" gesture), clamped into [0, maxContent - lensSize].
+export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOptions): UseDragPanResult => {
+  const [isDragging, setIsDragging] = useState(false);
+  const originRef = useRef<DragOrigin | null>(null);
+
+  // Keep the latest navState available to pointermove without re-binding the listener every render.
+  const navStateRef = useRef(navState);
+  navStateRef.current = navState;
+
+  const onPointerDown = useCallback<PointerEventHandler<HTMLElement>>(event => {
+    const target = event.currentTarget;
+    target.setPointerCapture(event.pointerId);
+    originRef.current = {
+      pointerId: event.pointerId,
+      startPageY: event.pageY,
+      startLensStart: navStateRef.current.lensStart,
+    };
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleMove = (event: PointerEvent) => {
+      const origin = originRef.current;
+      if (!origin || event.pointerId !== origin.pointerId) return;
+      const ns = navStateRef.current;
+      if (!Number.isFinite(ns.pixelPerMeter) || ns.pixelPerMeter <= 0) return;
+      const deltaPx = event.pageY - origin.startPageY;
+      const deltaMeters = deltaPx / ns.pixelPerMeter;
+      // Drag down (positive deltaY) feels like scrolling up, so subtract.
+      const next = clamp(origin.startLensStart - deltaMeters, 0, Math.max(0, ns.maxContent - ns.lensSize));
+      setNavState(prev => prev.setLensStart(next));
+    };
+
+    const handleEnd = (event: PointerEvent) => {
+      const origin = originRef.current;
+      if (!origin || event.pointerId !== origin.pointerId) return;
+      originRef.current = null;
+      setIsDragging(false);
+    };
+
+    container.addEventListener("pointermove", handleMove);
+    container.addEventListener("pointerup", handleEnd);
+    container.addEventListener("pointercancel", handleEnd);
+    return () => {
+      container.removeEventListener("pointermove", handleMove);
+      container.removeEventListener("pointerup", handleEnd);
+      container.removeEventListener("pointercancel", handleEnd);
+    };
+  }, [containerRef, setNavState]);
+
+  return { onPointerDown, isDragging };
+};

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
@@ -36,6 +36,9 @@ interface DragOrigin {
   startLensStart: number;
 }
 
+const isOriginForPointer = (origin: DragOrigin | null, pointerId: number): origin is DragOrigin =>
+  origin?.pointerId === pointerId;
+
 // Lifts the lens-overview drag-pan behavior up to any scrollable container. Pointer-move
 // updates lensStart inversely to deltaY (drag down -> lens moves up, matching the "grab the
 // page" gesture), clamped into [0, maxContent - lensSize].
@@ -72,7 +75,7 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
 
     const handleMove = (event: PointerEvent) => {
       const origin = originRef.current;
-      if (!origin || event.pointerId !== origin.pointerId) return;
+      if (!isOriginForPointer(origin, event.pointerId)) return;
       const ns = navStateRef.current;
       if (!Number.isFinite(ns.pixelPerMeter) || ns.pixelPerMeter <= 0) return;
       const deltaPx = event.pageY - origin.startPageY;
@@ -86,7 +89,7 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
 
     const handleEnd = (event: PointerEvent) => {
       const origin = originRef.current;
-      if (!origin || event.pointerId !== origin.pointerId) return;
+      if (!isOriginForPointer(origin, event.pointerId)) return;
       originRef.current = null;
       setIsDragging(false);
     };

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
@@ -28,6 +28,8 @@ interface UseDragPanResult {
 // Without it, dragging in pixels-per-meter space feels sluggish at typical zoom levels.
 const DRAG_SPEED_MULTIPLIER = 2;
 
+const isPannableNavState = (ns: NavState): boolean => ns.maxContent > ns.lensSize;
+
 interface DragOrigin {
   pointerId: number;
   startPageY: number;
@@ -45,12 +47,12 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
   const navStateRef = useRef(navState);
   navStateRef.current = navState;
 
-  const isPannable = navState.maxContent > navState.lensSize;
+  const isPannable = isPannableNavState(navState);
 
   const onPointerDown = useCallback<PointerEventHandler<HTMLElement>>(event => {
     const ns = navStateRef.current;
     // Skip the gesture entirely when the full content already fits; nothing to pan to.
-    if (ns.maxContent <= ns.lensSize) return;
+    if (!isPannableNavState(ns)) return;
     // Suppress the browser's default text-selection-on-drag behavior, otherwise selection-drag
     // races our pan-drag and the gesture stutters mid-move.
     event.preventDefault();

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
@@ -63,6 +63,8 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
       const deltaMeters = deltaPx / ns.pixelPerMeter;
       // Drag down (positive deltaY) feels like scrolling up, so subtract.
       const next = clamp(origin.startLensStart - deltaMeters, 0, Math.max(0, ns.maxContent - ns.lensSize));
+      // `next` is origin-relative (computed from the captured startLensStart), not state-relative,
+      // so the functional updater ignores `prev.lensStart` by design and just preserves the rest of prev.
       setNavState(prev => prev.setLensStart(next));
     };
 

--- a/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
+++ b/src/client/src/pages/detail/form/stratigraphy/navigation/useDragPan.ts
@@ -20,7 +20,13 @@ interface UseDragPanOptions {
 interface UseDragPanResult {
   onPointerDown: PointerEventHandler<HTMLElement>;
   isDragging: boolean;
+  // True when the visible window is smaller than the full content (i.e., there is something to pan to).
+  isPannable: boolean;
 }
+
+// Multiplies the 1-to-1 mouse-to-meter mapping so that a small drag moves the viewport noticeably.
+// Without it, dragging in pixels-per-meter space feels sluggish at typical zoom levels.
+const DRAG_SPEED_MULTIPLIER = 2;
 
 interface DragOrigin {
   pointerId: number;
@@ -39,13 +45,21 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
   const navStateRef = useRef(navState);
   navStateRef.current = navState;
 
+  const isPannable = navState.maxContent > navState.lensSize;
+
   const onPointerDown = useCallback<PointerEventHandler<HTMLElement>>(event => {
+    const ns = navStateRef.current;
+    // Skip the gesture entirely when the full content already fits; nothing to pan to.
+    if (ns.maxContent <= ns.lensSize) return;
+    // Suppress the browser's default text-selection-on-drag behavior, otherwise selection-drag
+    // races our pan-drag and the gesture stutters mid-move.
+    event.preventDefault();
     const target = event.currentTarget;
     target.setPointerCapture(event.pointerId);
     originRef.current = {
       pointerId: event.pointerId,
       startPageY: event.pageY,
-      startLensStart: navStateRef.current.lensStart,
+      startLensStart: ns.lensStart,
     };
     setIsDragging(true);
   }, []);
@@ -60,7 +74,7 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
       const ns = navStateRef.current;
       if (!Number.isFinite(ns.pixelPerMeter) || ns.pixelPerMeter <= 0) return;
       const deltaPx = event.pageY - origin.startPageY;
-      const deltaMeters = deltaPx / ns.pixelPerMeter;
+      const deltaMeters = (deltaPx / ns.pixelPerMeter) * DRAG_SPEED_MULTIPLIER;
       // Drag down (positive deltaY) feels like scrolling up, so subtract.
       const next = clamp(origin.startLensStart - deltaMeters, 0, Math.max(0, ns.maxContent - ns.lensSize));
       // `next` is origin-relative (computed from the captured startLensStart), not state-relative,
@@ -85,5 +99,5 @@ export const useDragPan = ({ navState, setNavState, containerRef }: UseDragPanOp
     };
   }, [containerRef, setNavState]);
 
-  return { onPointerDown, isDragging };
+  return { onPointerDown, isDragging, isPannable };
 };


### PR DESCRIPTION
Preparation for https://github.com/swisstopo/swissgeol-boreholes-suite/issues/2171

In the Chronostratigraphy and Lithostratigraphy the Zoom and Drag interactions now work on the main content, not only on the Lens