### PR TITLE
Serialize dev deploys to avoid helm lock races

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,6 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to dev cluster
     environment: dev
+    timeout-minutes: 15
+
+    # One deploy at a time. Don't cancel, a half-finished deploy blocks the next one
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
 
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config


### PR DESCRIPTION
Deploys now queue. Also disabled cancelling, since killing helm mid-upgrade leaves the release stuck, which blocks any subsequent deploys and needs manual fixing.