### PR TITLE
Preserve PYTHONPATH for dataextraction-api

### DIFF
--- a/charts/swissgeol-boreholes/templates/dataextraction-api.yaml
+++ b/charts/swissgeol-boreholes/templates/dataextraction-api.yaml
@@ -71,6 +71,9 @@ spec:
           - name: tmp
             mountPath: /tmp
           env:
+            # Set explicitly, or AWS telemetry overwrites it and the app won't start
+            - name: PYTHONPATH
+              value: /app/src
             - name: AWS_DEFAULT_REGION
               value: eu-central-1
             - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
The AWS Cluster (dev only it seems) injects telemetry and overwrote PYTHONPATH, crashlooping dataextraction-api. The env is not defined on the manifest, only in the docker container, which causes the AWS Cluster to overwrite the whole env instead of extending it.

Explicitly defining it here should hopefully fix this.
