### PR TITLE
Report one deployment status per deploy run

### DIFF
--- a/.github/workflows/deploy-int.yml
+++ b/.github/workflows/deploy-int.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Deploy to int cluster (${{ matrix.release }})
-    environment: int
 
     permissions:
       id-token: write
@@ -71,3 +70,17 @@ jobs:
             ${{ matrix.values }} \
             -n ${{ matrix.namespace }} \
             --install --wait --timeout 5m
+
+  # Records one deployment for all releases, so the environment shows a single status
+  status:
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: ${{ !cancelled() }}
+    name: Report int deployment status
+    environment: int
+    permissions: {}
+
+    steps:
+      - name: Fail if any release failed to deploy
+        if: ${{ needs.deploy.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,7 +11,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy to prod cluster (${{ matrix.release }})
-    environment: prod
 
     permissions:
       id-token: write
@@ -69,3 +68,17 @@ jobs:
             ${{ matrix.values }} \
             -n ${{ matrix.namespace }} \
             --install --wait --timeout 5m
+
+  # Records one deployment for all releases, so the environment shows a single status
+  status:
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: ${{ !cancelled() }}
+    name: Report prod deployment status
+    environment: prod
+    permissions: {}
+
+    steps:
+      - name: Fail if any release failed to deploy
+        if: ${{ needs.deploy.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Added a new job that records a unified status for all 5 namespace deployments on prod and int. This should fix the status as it's displayed on github (currently it always shows as those environments being inactive, even tho the deployments are successful).

This replaces the old environment in github, and how it was displayed.