### PR TITLE
Simplify env yamls

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -40,11 +40,11 @@ jobs:
 
       - name: Validate int environment values
         run: |
-          helm lint charts/swissgeol-boreholes -f environments/int/boreholes.values.yaml
-          helm lint charts/swissgeol-boreholes -f environments/int/boreholes.values.yaml -f environments/int/boreholes-ext.values.yaml
-          helm lint charts/swissgeol-boreholes -f environments/int/boreholes.values.yaml -f environments/int/boreholes-view.values.yaml
-          helm lint charts/swissgeol-boreholes-extern-sync -f environments/int/extern-sync.values.yaml
-          helm lint charts/swissgeol-boreholes-view-sync -f environments/int/view-sync.values.yaml
+          helm lint charts/swissgeol-boreholes -f environments/int/version.values.yaml -f environments/int/boreholes.values.yaml
+          helm lint charts/swissgeol-boreholes -f environments/int/version.values.yaml -f environments/int/boreholes.values.yaml -f environments/int/boreholes-ext.values.yaml
+          helm lint charts/swissgeol-boreholes -f environments/int/version.values.yaml -f environments/int/boreholes.values.yaml -f environments/int/boreholes-view.values.yaml
+          helm lint charts/swissgeol-boreholes-extern-sync -f environments/int/version.values.yaml -f environments/int/extern-sync.values.yaml
+          helm lint charts/swissgeol-boreholes-view-sync -f environments/int/version.values.yaml -f environments/int/view-sync.values.yaml
 
       - name: Validate prod environment values
         run: |
@@ -52,4 +52,4 @@ jobs:
           helm lint charts/swissgeol-boreholes -f environments/prod/boreholes.values.yaml -f environments/prod/boreholes-ext.values.yaml
           helm lint charts/swissgeol-boreholes -f environments/prod/boreholes.values.yaml -f environments/prod/boreholes-view.values.yaml
           helm lint charts/swissgeol-boreholes-extern-sync -f environments/prod/extern-sync.values.yaml
-          helm lint charts/swissgeol-boreholes-view-sync
+          helm lint charts/swissgeol-boreholes-view-sync -f environments/prod/view-sync.values.yaml

--- a/.github/workflows/deploy-int.yml
+++ b/.github/workflows/deploy-int.yml
@@ -18,28 +18,29 @@ jobs:
       contents: read
 
     strategy:
+      # version.values.yaml comes first everywhere, so all releases deploy the same app version
       matrix:
         include:
           - release: swissgeol-boreholes
             chart: swissgeol-boreholes
             namespace: swissgeol-boreholes
-            values: -f environments/int/boreholes.values.yaml
+            values: -f environments/int/version.values.yaml -f environments/int/boreholes.values.yaml
           - release: swissgeol-boreholes-ext
             chart: swissgeol-boreholes
             namespace: swissgeol-boreholes-ext
-            values: -f environments/int/boreholes.values.yaml -f environments/int/boreholes-ext.values.yaml
+            values: -f environments/int/version.values.yaml -f environments/int/boreholes.values.yaml -f environments/int/boreholes-ext.values.yaml
           - release: swissgeol-boreholes-view
             chart: swissgeol-boreholes
             namespace: swissgeol-boreholes-view
-            values: -f environments/int/boreholes.values.yaml -f environments/int/boreholes-view.values.yaml
+            values: -f environments/int/version.values.yaml -f environments/int/boreholes.values.yaml -f environments/int/boreholes-view.values.yaml
           - release: swissgeol-boreholes-extern-sync
             chart: swissgeol-boreholes-extern-sync
             namespace: swissgeol-boreholes-extern-sync
-            values: -f environments/int/extern-sync.values.yaml
+            values: -f environments/int/version.values.yaml -f environments/int/extern-sync.values.yaml
           - release: swissgeol-boreholes-view-sync
             chart: swissgeol-boreholes-view-sync
             namespace: swissgeol-boreholes-view-sync
-            values: -f environments/int/view-sync.values.yaml
+            values: -f environments/int/version.values.yaml -f environments/int/view-sync.values.yaml
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,6 +38,7 @@ jobs:
           - release: swissgeol-boreholes-view-sync
             chart: swissgeol-boreholes-view-sync
             namespace: swissgeol-boreholes-view-sync
+            values: -f environments/prod/view-sync.values.yaml
 
     steps:
       - name: Checkout repository

--- a/environments/int/boreholes.values.yaml
+++ b/environments/int/boreholes.values.yaml
@@ -2,6 +2,5 @@
 # Also serves as the base for boreholes-ext and boreholes-view namespaces.
 app:
   domain: int-boreholes.swissgeol.ch
-  version: v2.1.1748
 s3:
   endpoint: https://s3.eu-central-1.amazonaws.com

--- a/environments/int/extern-sync.values.yaml
+++ b/environments/int/extern-sync.values.yaml
@@ -1,7 +1,6 @@
 # Environment-specific overrides for INT — swissgeol-boreholes-extern-sync namespace.
 app:
   schedule: "*/10 * * * *"
-  version: v2.1.1748
 configuration:
   targetDefaultWorkgroupName: Sync
   targetDefaultUserSub: sub_admin

--- a/environments/int/version.values.yaml
+++ b/environments/int/version.values.yaml
@@ -1,0 +1,5 @@
+# App version deployed to INT, shared by every release in the environment.
+# Layered under all other INT values files so the main app and the sync jobs
+# always run the same version.
+app:
+  version: v2.1.1748

--- a/environments/int/view-sync.values.yaml
+++ b/environments/int/view-sync.values.yaml
@@ -1,4 +1,3 @@
 # Environment-specific overrides for INT — swissgeol-boreholes-view-sync namespace.
 app:
   schedule: "*/10 * * * *"
-  version: v2.1.1748


### PR DESCRIPTION
INT pinned `app.version` separately in three values files, which made no sense since we'd never run seperate versions on the namespaces.

- Add `environments/int/version.values.yaml`. Bumping INT is now one line in one file.
- Fix `deploy-prod.yml`: view-sync passed no values file, so it ran the chart defaults.
- Lint both fixes in `chart-lint.yml`.
