### PR TITLE
Resource adjustments

### DIFF
--- a/charts/swissgeol-boreholes/templates/client.yaml
+++ b/charts/swissgeol-boreholes/templates/client.yaml
@@ -53,11 +53,12 @@ spec:
             failureThreshold: 30
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 128Mi
               ephemeral-storage: 1Gi
             limits:
-              cpu: 250m
+              # Kept high, throttling was failing the healthz probe
+              cpu: 1000m
               memory: 256Mi
               ephemeral-storage: 2Gi
           securityContext:

--- a/charts/swissgeol-boreholes/templates/dataextraction-api.yaml
+++ b/charts/swissgeol-boreholes/templates/dataextraction-api.yaml
@@ -51,12 +51,13 @@ spec:
             timeoutSeconds: 2
             failureThreshold: 30
           resources:
+            # Request must match the ~4Gi the app allocates at startup, or it lands on a node too small and is OOMKilled
             requests:
-              cpu: 500m
-              memory: 1024Mi
+              cpu: 1000m
+              memory: 4Gi
               ephemeral-storage: 2Gi
             limits:
-              cpu: 1500m
+              cpu: 1000m
               memory: 4Gi
               ephemeral-storage: 4Gi
           securityContext:


### PR DESCRIPTION
- Adjust resources for dataextraction so it becomes a pod of type `guaranteed` (on paper). This should prevent OOMKilled errors in the future. The Pod is extremely hungry, anything below a 4Gi Request & Limit caused it to be killed for memory reasons.
- Adjust the limit for the Client, since it can cause some issues with the healthz probe in some rare instances. 